### PR TITLE
OHFJIRA-2 libs upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk6
+  - oraclejdk7
 install: mvn install -DskipTests=true
 script: mvn test
 notifications:

--- a/core-api/pom.xml
+++ b/core-api/pom.xml
@@ -94,7 +94,7 @@
         <!-- misc -->
         <dependency>
             <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.0-api</artifactId>
+            <artifactId>hibernate-jpa-2.1-api</artifactId>
         </dependency>
 
     </dependencies>

--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import org.apache.camel.ExchangeProperty;
 import org.openhubframework.openhub.api.entity.ExternalSystemExtEnum;
 import org.openhubframework.openhub.api.entity.Message;
 import org.openhubframework.openhub.api.entity.MsgStateEnum;
@@ -33,7 +34,6 @@ import org.openhubframework.openhub.api.exception.ErrorExtEnum;
 
 import org.apache.camel.Header;
 import org.apache.camel.Properties;
-import org.apache.camel.Property;
 
 
 /**
@@ -101,8 +101,8 @@ public interface MessageService {
      */
     void setStatePartlyFailed(@Header(MSG_HEADER) Message msg,
                               Exception ex,
-                              @Property(EXCEPTION_ERROR_CODE) @Nullable ErrorExtEnum errCode,
-                              @Property(CUSTOM_DATA_PROP) @Nullable String customData,
+                              @ExchangeProperty(EXCEPTION_ERROR_CODE) @Nullable ErrorExtEnum errCode,
+                              @ExchangeProperty(CUSTOM_DATA_PROP) @Nullable String customData,
                               @Properties Map<String, Object> props);
 
     /**
@@ -118,8 +118,8 @@ public interface MessageService {
      */
     void setStateFailed(@Header(MSG_HEADER) Message msg,
                         Exception ex,
-                        @Property(EXCEPTION_ERROR_CODE) @Nullable ErrorExtEnum errCode,
-                        @Property(CUSTOM_DATA_PROP) @Nullable String customData,
+                        @ExchangeProperty(EXCEPTION_ERROR_CODE) @Nullable ErrorExtEnum errCode,
+                        @ExchangeProperty(CUSTOM_DATA_PROP) @Nullable String customData,
                         @Properties Map<String, Object> props);
 
     /**

--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
@@ -43,8 +43,15 @@ import org.apache.camel.Properties;
  */
 public interface MessageService {
 
-    public static final String BEAN = "messageService";
+    String BEAN = "messageService";
 
+    /**
+     * Inserts new message.
+     *
+     * @param message message that will be saved
+     */
+    void insertMessage(Message message);
+    
     /**
      * Inserts new messages.
      *

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -115,7 +115,7 @@
             <artifactId>hibernate-entitymanager</artifactId>
         </dependency>
         <dependency>
-            <groupId>c3p0</groupId>
+            <groupId>com.mchange</groupId>
             <artifactId>c3p0</artifactId>
         </dependency>
 

--- a/core/src/main/java/org/openhubframework/openhub/core/alerts/AlertsSchedulerRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/alerts/AlertsSchedulerRoute.java
@@ -48,13 +48,14 @@ public class AlertsSchedulerRoute extends SpringRouteBuilder {
 
     @Override
     public final void configure() throws Exception {
-        String uri = RepairProcessingMsgRoute.JOB_GROUP_NAME + "/" + JOB_NAME
-                + "?trigger.repeatInterval=" + (repeatInterval * 1000)
-                + "&trigger.repeatCount=" + SimpleTrigger.REPEAT_INDEFINITELY;
+        if (repeatInterval != -1) {
+            String uri = RepairProcessingMsgRoute.JOB_GROUP_NAME + "/" + JOB_NAME
+                    + "?trigger.repeatInterval=" + (repeatInterval * 1000)
+                    + "&trigger.repeatCount=" + SimpleTrigger.REPEAT_INDEFINITELY;
+            from("quartz2://" + uri)
+                    .routeId("alerts" + AbstractBasicRoute.ROUTE_SUFFIX)
 
-        from("quartz2://" + uri)
-                .routeId("alerts" + AbstractBasicRoute.ROUTE_SUFFIX)
-
-                .beanRef(AlertsCheckingService.BEAN, "checkAlerts");
+                    .bean(AlertsCheckingService.BEAN, "checkAlerts");
+        }
     }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchInMessageRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchInMessageRoute.java
@@ -125,7 +125,7 @@ public class AsynchInMessageRoute extends AbstractBasicRoute {
                 .validate(header(OPERATION_HEADER).isNotNull())
 
                 // check if ESB is not stopping?
-                .beanRef(ROUTE_BEAN, "checkStopping").id("stopChecking")
+                .bean(ROUTE_BEAN, "checkStopping").id("stopChecking")
 
                 // extract trace header, trace header is mandatory
                 .process(new TraceHeaderProcessor(true, validatorList))
@@ -160,7 +160,7 @@ public class AsynchInMessageRoute extends AbstractBasicRoute {
                 .to(URI_GUARANTEED_ORDER_ROUTE)
 
                 // create OK response
-                .beanRef(ROUTE_BEAN, "createOkResponse")
+                .bean(ROUTE_BEAN, "createOkResponse")
 
             .endDoTry()
 
@@ -225,11 +225,11 @@ public class AsynchInMessageRoute extends AbstractBasicRoute {
                     .when().method(ROUTE_BEAN, "isMsgInGuaranteedOrder")
                         // no guaranteed order or message in the right order => continue
 
-                        .beanRef(ROUTE_BEAN, "saveLogContextParams")
+                        .bean(ROUTE_BEAN, "saveLogContextParams")
 
-                        .beanRef(ROUTE_BEAN, "setInsertQueueTimestamp")
+                        .bean(ROUTE_BEAN, "setInsertQueueTimestamp")
 
-                        .beanRef(ROUTE_BEAN, "setMsgPriority")
+                        .bean(ROUTE_BEAN, "setMsgPriority")
 
                         // redirect message asynchronously for next processing
                         .to(ExchangePattern.RobustInOnly, AsynchConstants.URI_ASYNC_MSG).id("toAsyncRoute")
@@ -237,7 +237,7 @@ public class AsynchInMessageRoute extends AbstractBasicRoute {
                     .otherwise()
 
                         // message isn't in right guaranteed order => postpone
-                        .beanRef(ROUTE_BEAN, "postponeMessage")
+                        .bean(ROUTE_BEAN, "postponeMessage")
                 .end()
 
                 .process(new Processor() {

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRoute.java
@@ -150,7 +150,7 @@ public class AsynchMessageRoute extends AbstractBasicRoute {
         // route for asynchronous processing
         from(AsynchConstants.URI_ASYNC_MSG)
                 .routeId(ROUTE_ID_ASYNC)
-                .beanRef(ROUTE_BEAN, "setLogContextParams")
+                .bean(ROUTE_BEAN, "setLogContextParams")
                 .to(URI_SYNC_MSG);
 
 
@@ -200,11 +200,11 @@ public class AsynchMessageRoute extends AbstractBasicRoute {
                 .choice()
                     .when(header(NO_EFFECT_PROCESS_HEADER).isEqualTo(Boolean.TRUE))
                          // mark message as PARTLY_FAILED but without increasing error count
-                        .beanRef(MessageService.BEAN, "setStatePartlyFailedWithoutError")
+                        .bean(MessageService.BEAN, "setStatePartlyFailedWithoutError")
 
                     .when().method(ROUTE_BEAN, "checkParentMessage")
                         // it's a parent message
-                        .beanRef(MessageService.BEAN, "setStateWaiting")
+                        .bean(MessageService.BEAN, "setStateWaiting")
 
                         .process(new Processor() {
                             @Override
@@ -220,7 +220,7 @@ public class AsynchMessageRoute extends AbstractBasicRoute {
 
                     .otherwise()
                         // everything OK => mark processing as successful
-                        .beanRef(MessageService.BEAN, "setStateOk")
+                        .bean(MessageService.BEAN, "setStateOk")
 
                         .process(new Processor() {
                             @Override
@@ -261,7 +261,7 @@ public class AsynchMessageRoute extends AbstractBasicRoute {
 
                 .otherwise()
                     // => mark as PARTLY FAILED
-                    .beanRef(MessageService.BEAN, "setStatePartlyFailed")
+                    .bean(MessageService.BEAN, "setStatePartlyFailed")
 
                     .process(new Processor() {
                         @Override
@@ -285,7 +285,7 @@ public class AsynchMessageRoute extends AbstractBasicRoute {
             .end()
 
             // => completely FAILED
-            .beanRef(MessageService.BEAN, "setStateFailed")
+            .bean(MessageService.BEAN, "setStateFailed")
 
             .process(new Processor() {
                 @Override
@@ -309,7 +309,7 @@ public class AsynchMessageRoute extends AbstractBasicRoute {
             .routeId(ROUTE_ID_POST_PROCESS_AFTER_FAILED)
             .validate(header(MSG_HEADER).isNotNull())
             .to(AsynchConstants.URI_CONFIRM_MESSAGE)
-            .beanRef(ROUTE_BEAN, "sendMailToAdmin").id("sendEmail");
+            .bean(ROUTE_BEAN, "sendMailToAdmin").id("sendEmail");
 
 
         // confirmation route
@@ -323,10 +323,10 @@ public class AsynchMessageRoute extends AbstractBasicRoute {
                 .choice()
                     .when(body().isInstanceOf(ExternalCall.class))
                         // existing confirmation external call - just update it to failed state
-                        .beanRef(ConfirmationService.BEAN, "confirmationFailed")
+                        .bean(ConfirmationService.BEAN, "confirmationFailed")
                     .otherwise()
                         // no existing confirmation external call - record a new one with failed state
-                        .beanRef(ConfirmationService.BEAN, "insertFailedConfirmation")
+                        .bean(ConfirmationService.BEAN, "insertFailedConfirmation")
                 .end()
             .end()
 
@@ -339,11 +339,11 @@ public class AsynchMessageRoute extends AbstractBasicRoute {
             .end()
 
             // note: if there it's child message then it's without confirmation (need to do it)
-            .beanRef(ConfirmationCallback.BEAN, "confirm")
+            .bean(ConfirmationCallback.BEAN, "confirm")
 
             .filter(body().isInstanceOf(ExternalCall.class))
                 // for successful confirmations only record if it's a repeating attempt
-                .beanRef(ConfirmationService.BEAN, "confirmationComplete")
+                .bean(ConfirmationService.BEAN, "confirmationComplete")
             .end();
     }
 

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRoute.java
@@ -243,7 +243,7 @@ public class AsynchMessageRoute extends AbstractBasicRoute {
                 .log(LoggingLevel.ERROR, "Error while handling error: ${exception.stacktrace}")
             .end()
 
-            .validate(property(Exchange.EXCEPTION_CAUGHT).isNotNull())
+            .validate(exchangeProperty(Exchange.EXCEPTION_CAUGHT).isNotNull())
 
             .log(LoggingLevel.WARN,
                     "Error occurred during route processing: ${property." + Exchange.EXCEPTION_CAUGHT + "}")

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/confirm/ConfirmationsPoolRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/confirm/ConfirmationsPoolRoute.java
@@ -55,6 +55,6 @@ public class ConfirmationsPoolRoute extends SpringRouteBuilder {
         from("quartz2://" + uri)
                 .routeId("confirmationsPool" + AbstractBasicRoute.ROUTE_SUFFIX)
 
-                .beanRef("jobStarterForConfirmationPooling", "start");
+                .bean("jobStarterForConfirmationPooling", "start");
     }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
@@ -52,18 +52,25 @@ public class MessageServiceImpl implements MessageService {
 
     @Transactional
     @Override
+    public void insertMessage(Message message) {
+        Assert.notNull(message, "the message must not be null");
+        Assert.state(message.getState() == MsgStateEnum.NEW || message.getState() == MsgStateEnum.PROCESSING,
+                "new message can be in NEW or PROCESSING state only");
+
+        message.setLastUpdateTimestamp(new Date());
+
+        messageDao.insert(message);
+
+        Log.debug("Inserted new message " + message.toHumanString());        
+    }
+
+    @Transactional
+    @Override
     public void insertMessages(Collection<Message> messages) {
         Assert.notNull(messages, "the messages must not be null");
 
         for (Message msg : messages) {
-            Assert.state(msg.getState() == MsgStateEnum.NEW || msg.getState() == MsgStateEnum.PROCESSING,
-                    "new message can be in NEW or PROCESSING state only");
-
-            msg.setLastUpdateTimestamp(new Date());
-
-            messageDao.insert(msg);
-
-            Log.debug("Inserted new message " + msg.toHumanString());
+            insertMessage(msg);
         }
     }
 

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/queue/PartlyFailedMessagesPoolRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/queue/PartlyFailedMessagesPoolRoute.java
@@ -63,7 +63,7 @@ public class PartlyFailedMessagesPoolRoute extends SpringRouteBuilder {
 
                 // allow only if ESB not stopping
                 .choice().when().method(ROUTE_BEAN, "isNotInStoppingMode")
-                    .beanRef("jobStarterForMessagePooling", "start")
+                    .bean("jobStarterForMessagePooling", "start")
                 .end();
     }
 

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/repair/RepairProcessingExtCallRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/repair/RepairProcessingExtCallRoute.java
@@ -57,6 +57,6 @@ public class RepairProcessingExtCallRoute extends SpringRouteBuilder {
         from("quartz2://" + uri)
                 .routeId("repairExternalCallProcess" + AbstractBasicRoute.ROUTE_SUFFIX)
 
-                .beanRef(RepairExternalCallService.BEAN, "repairProcessingExternalCalls");
+                .bean(RepairExternalCallService.BEAN, "repairProcessingExternalCalls");
     }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/repair/RepairProcessingMsgRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/repair/RepairProcessingMsgRoute.java
@@ -59,6 +59,6 @@ public class RepairProcessingMsgRoute extends SpringRouteBuilder {
         from("quartz2://" + uri)
                 .routeId("repairMessageProcess" + AbstractBasicRoute.ROUTE_SUFFIX)
 
-                .beanRef(RepairMessageService.BEAN, "repairProcessingMessages");
+                .bean(RepairMessageService.BEAN, "repairProcessingMessages");
     }
 }

--- a/core/src/main/resources/applicationCore.cfg
+++ b/core/src/main/resources/applicationCore.cfg
@@ -78,7 +78,7 @@ requestSaving.enable=false
 # pattern for filtering endpoints URI which requests/response should be saved
 requestSaving.endpointFilter=^(spring-ws|servlet).*$
 
-# How often to run checking of alerts (in seconds)
-alerts.repeatTime = 300
+# How often to run checking of alerts (in seconds), value -1 no run checking of alerts
+alerts.repeatTime = -1
 
 

--- a/core/src/test/java/org/openhubframework/openhub/core/camel/CamelLoopStopTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/camel/CamelLoopStopTest.java
@@ -16,8 +16,6 @@
 
 package org.openhubframework.openhub.core.camel;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.Processor;
@@ -51,12 +49,8 @@ public class CamelLoopStopTest extends CamelTestSupport {
     public void testStoppingLoopWithCopy() throws Exception {
         reachedRouteTWO = false;
 
-        try {
-            producer.requestBody("direct:routeLoopCopy", "any body");
-            fail();
-        } catch (Exception ex) {
-            assertThat(ex.getCause(), instanceOf(IllegalStateException.class));
-        }
+        producer.requestBody("direct:routeLoopCopy", "any body");
+        // in previous version of camel 2.13.x this call throws IllegalStateException, current version fixes this confusing behaviour 
     }
 
     @Test

--- a/core/src/test/java/org/openhubframework/openhub/core/camel/CamelMvelEmptyTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/camel/CamelMvelEmptyTest.java
@@ -29,26 +29,27 @@ public class CamelMvelEmptyTest extends CamelTestSupport {
     ProducerTemplate producer;
 
     /**
-     * Currently MVEL cannot handle numeric "== empty",
+     * MVEL distributed by Camel 2.13 cannot handle numeric "== empty",
      * despite the fact that it mentions 0 value for number in language guide:
-     * http://mvel.codehaus.org/Value+Emptiness
+     * http://mvel.codehaus.org/Value+Emptiness, and RuntimeException error occurred.
+     * Now this confusing behaviour is fixed.
      */
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testMvelEmptyLongObject() {
-        String result = producer.requestBody("direct:routeONE", new MyWrap<Long>(0L), String.class);
+        String result = producer.requestBody("direct:routeONE", new MyWrap<>(0L), String.class);
         assertEquals("FALSE", result);
 
-        result = producer.requestBody("direct:routeONE", new MyWrap<Long>(1L), String.class);
+        result = producer.requestBody("direct:routeONE", new MyWrap<>(1L), String.class);
         assertEquals("TRUE", result);
 
-        result = producer.requestBody("direct:routeONE", new MyWrap<Long>(-1L), String.class);
+        result = producer.requestBody("direct:routeONE", new MyWrap<>(-1L), String.class);
         assertEquals("TRUE", result);
 
         result = producer.requestBody("direct:routeONE", new MyWrap<Long>(null), String.class);
         assertEquals("FALSE", result);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testMvelEmptyLongPrimitive() {
         String result = producer.requestBody("direct:routeONE", new MyWrapPrimitive(1L), String.class);
         assertEquals("TRUE", result);

--- a/core/src/test/java/org/openhubframework/openhub/core/camel/CamelStopOnCompletionTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/camel/CamelStopOnCompletionTest.java
@@ -44,7 +44,8 @@ public class CamelStopOnCompletionTest extends CamelTestSupport {
     @Test
     public void testStopOnCompletion() throws InterruptedException {
         MockEndpoint mock = getMockEndpoint("mock:test");
-        mock.expectedMessageCount(0);
+        // changed behavior of onCompletion since 2.13.x camel version - earlier asynchronous by default, now synchronously
+        mock.expectedMessageCount(2);
 
         String result = producer.requestBody("direct:routeONE", "any body", String.class);
         assertEquals("any body-routeONE-routeTWO", result);

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/confirm/DelegateConfirmationCallbackTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/confirm/DelegateConfirmationCallbackTest.java
@@ -16,7 +16,8 @@
 
 package org.openhubframework.openhub.core.common.asynch.confirm;
 
-import static junit.framework.Assert.assertNotNull;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 import java.util.Collections;
 import java.util.Set;
@@ -47,7 +48,7 @@ public class DelegateConfirmationCallbackTest extends AbstractCoreTest {
 
     @Test
     public void testGetImplementation() throws Exception {
-        assertNotNull(confirmation.getImplementation(getSourceSystem("CRM")));
+        assertThat(confirmation.getImplementation(getSourceSystem("CRM")), notNullValue());
     }
 
     private static ExternalSystemConfirmation getDefaultImplementation(final String sourceSystem) {

--- a/pom.xml
+++ b/pom.xml
@@ -54,16 +54,17 @@
 
     <properties>
         <!-- java language version -->
-        <java.version>1.6</java.version>
+        <java.version>1.7</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <camel-version>2.13.2</camel-version>
-        <junit-version>4.11</junit-version>
-        <spring-version>3.2.4.RELEASE</spring-version>
-        <spring-ws-version>2.1.2.RELEASE</spring-ws-version>
-        <spring-security-version>3.1.3.RELEASE</spring-security-version>
-        <hibernate-version>4.2.0.Final</hibernate-version>
-        <slf4j-version>1.7.3</slf4j-version>
+        <camel-version>2.17.3</camel-version>
+        <junit-version>4.12</junit-version>
+        <spring-version>4.3.4.RELEASE</spring-version>
+        <spring-ws-version>2.2.2.RELEASE</spring-ws-version>
+        <spring-security-version>4.1.3.RELEASE</spring-security-version>
+        <!-- Hibernate 5.1 and older versions require at least Java 1.6 -->
+        <hibernate-version>5.1.2.Final</hibernate-version>
+        <slf4j-version>1.7.21</slf4j-version>
     </properties>
 
     <dependencyManagement>
@@ -353,6 +354,12 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-quartz2</artifactId>
                 <version>${camel-version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>c3p0</groupId>
+                        <artifactId>c3p0</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.camel</groupId>
@@ -374,8 +381,8 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate.javax.persistence</groupId>
-                <artifactId>hibernate-jpa-2.0-api</artifactId>
-                <version>1.0.1.Final</version>
+                <artifactId>hibernate-jpa-2.1-api</artifactId>
+                <version>1.0.0.Final</version>
                 <scope>compile</scope>
                 <exclusions>
                     <exclusion>
@@ -387,12 +394,12 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>9.2-1003-jdbc4</version>
+                <version>9.4.1211.jre7</version>
             </dependency>
             <dependency>
-                <groupId>c3p0</groupId>
+                <groupId>com.mchange</groupId>
                 <artifactId>c3p0</artifactId>
-                <version>0.9.1.2</version>
+                <version>0.9.5.2</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>
@@ -503,7 +510,7 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.20</version>
+                <version>2.3.23</version>
             </dependency>
             <dependency>
                 <groupId>jcifs</groupId>
@@ -581,6 +588,7 @@
 
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <!-- be careful if upgrade, Travis has problem with higher version -->
                     <version>2.18</version>
                 </plugin>
 
@@ -661,7 +669,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.0.4</version>
                     <configuration>
                         <findbugsXmlOutput>true</findbugsXmlOutput>
                         <xmlOutput>true</xmlOutput>
@@ -672,7 +680,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.7</version>
                     <configuration>
                         <sourceEncoding>utf-8</sourceEncoding>
                         <targetJdk>${java.version}</targetJdk>
@@ -716,11 +724,11 @@
                     <version>2.9.1</version>
                     <configuration>
                         <links>
-                            <link>http://camel.apache.org/maven/camel-2.13.0/camel-core/apidocs/</link>
-                            <link>http://camel.apache.org/maven/camel-2.13.0/camel-spring/apidocs/</link>
-                            <link>http://camel.apache.org/maven/camel-2.13.0/camel-spring-ws/apidocs/</link>
-                            <link>http://docs.spring.io/spring-ws/sites/2.0/apidocs/</link>
-                            <link>http://docs.spring.io/spring/docs/3.2.4.RELEASE/javadoc-api/</link>
+                            <!-- actually javadoc.io service does not provide package list under standard /package-list URL -->
+                            <link>http://www.javadoc.io/doc/org.apache.camel/camel-core/2.17.3/</link>
+                            <link>http://www.javadoc.io/doc/org.apache.camel/camel-spring/2.17.3/</link>
+                            <link>http://www.javadoc.io/doc/org.springframework.ws/spring-ws-core/2.2.2.RELEASE/</link>
+                            <link>http://www.javadoc.io/doc/org.springframework/spring-core/4.3.4.RELEASE/</link>
                         </links>
                         <aggregate>true</aggregate>
                         <additionalDependencies>

--- a/test/src/main/java/org/openhubframework/openhub/test/AbstractDbTest.java
+++ b/test/src/main/java/org/openhubframework/openhub/test/AbstractDbTest.java
@@ -40,7 +40,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.transaction.TransactionConfiguration;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -52,7 +51,6 @@ import org.springframework.transaction.support.TransactionTemplate;
  * @author Petr Juza
  */
 @ContextConfiguration(locations = {"classpath:/META-INF/test_persistence.xml"})
-@TransactionConfiguration(transactionManager = "jpaTxManager")
 public abstract class AbstractDbTest extends AbstractTest {
 
     /**

--- a/web-admin/pom.xml
+++ b/web-admin/pom.xml
@@ -59,7 +59,7 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>c3p0</groupId>
+                    <groupId>com.mchange</groupId>
                     <artifactId>c3p0</artifactId>
                 </dependency>
                 <dependency>

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/DefaultFreeMarkerConfigurer.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/DefaultFreeMarkerConfigurer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web;
+
+import freemarker.ext.jsp.TaglibFactory;
+import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
+
+
+/**
+ * FreeMarker configurer that supports {@literal TagLib} processing.
+ *
+ * @author Tomas Hanus
+ * @see FreeMarkerConfigurer
+ * @since 1.0
+ */
+public class DefaultFreeMarkerConfigurer extends FreeMarkerConfigurer {
+
+    @Override
+    public TaglibFactory getTaglibFactory() {
+        TaglibFactory tagLibFactory = super.getTaglibFactory();
+        if (tagLibFactory.getObjectWrapper() == null) {
+            tagLibFactory.setObjectWrapper(super.getConfiguration().getObjectWrapper());
+        }
+        return tagLibFactory;
+    }
+}

--- a/web-admin/src/main/resources/META-INF/sp_camel_services.xml
+++ b/web-admin/src/main/resources/META-INF/sp_camel_services.xml
@@ -38,8 +38,8 @@
     <beans profile="prod">
         <bean id="confirmationCallback" class="org.openhubframework.openhub.core.common.asynch.confirm.DelegateConfirmationCallback"/>
 
-        <bean id="quartz" class="org.apache.camel.component.quartz2.QuartzComponent">
-            <property name="startDelayedSeconds" value="30"/>
+        <bean id="quartz2" class="org.apache.camel.component.quartz2.QuartzComponent">
+            <property name="startDelayedSeconds" value="90"/>
         </bean>
     </beans>
 

--- a/web-admin/src/main/resources/META-INF/sp_ws.xml
+++ b/web-admin/src/main/resources/META-INF/sp_ws.xml
@@ -13,8 +13,8 @@
     <bean id="endpointMapping" class="org.apache.camel.component.spring.ws.bean.CamelEndpointMapping">
         <property name="interceptors">
             <list>
-                <ref local="loggingInterceptor"/>
-                <ref local="validatingInterceptor"/>
+                <ref bean="loggingInterceptor"/>
+                <ref bean="validatingInterceptor"/>
             </list>
         </property>
     </bean>

--- a/web-admin/src/main/webapp/WEB-INF/rootSecurity.xml
+++ b/web-admin/src/main/webapp/WEB-INF/rootSecurity.xml
@@ -3,7 +3,7 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="
              http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-             http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.1.xsd">
+             http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
 
     <beans:description>
         Spring security configuration.
@@ -11,13 +11,15 @@
 
     <!-- HTTP basic authentication for web services -->
     <http pattern="/ws/**">
-        <intercept-url pattern="/ws/**" access="ROLE_WS"/>
+        <csrf disabled="true"/>
+        <intercept-url pattern="/ws/**" access="hasRole('ROLE_WS')"/>
         <http-basic entry-point-ref="authenticationEntryPoint"/>
         <logout/>
     </http>
 
     <!-- Form based authentication for admin console -->
-    <http entry-point-ref="loginUrlAuthenticationEntryPoint" use-expressions="true">
+    <http entry-point-ref="loginUrlAuthenticationEntryPoint">
+        <csrf disabled="true"/>
         <intercept-url pattern="/web/admin/homepage/**" access="permitAll"/>
         <intercept-url pattern="/web/admin/login/**" access="permitAll"/>
         <intercept-url pattern="/web/admin/**" access="hasRole('ROLE_WEB')"/>
@@ -26,9 +28,7 @@
         <form-login
                 login-page="/web/admin/login"
                 default-target-url="/web/admin/console"
-                authentication-failure-url="/web/admin/login?error"
-                username-parameter="username"
-                password-parameter="password" />
+                authentication-failure-url="/web/admin/login?error" />
         <logout logout-success-url="/web/admin/homepage" />
     </http>
 
@@ -38,7 +38,7 @@
     </beans:bean>
 
     <beans:bean id="loginUrlAuthenticationEntryPoint" class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
-        <beans:property name="loginFormUrl" value="/web/admin/login" />
+        <beans:constructor-arg name="loginFormUrl" value="/web/admin/login" />
     </beans:bean>
 
     <authentication-manager alias="authManager">
@@ -53,11 +53,11 @@
 
     <beans:bean id="accessDecisionManager" class="org.springframework.security.access.vote.AffirmativeBased">
         <beans:property name="allowIfAllAbstainDecisions" value="true"/>
-        <beans:property name="decisionVoters">
+        <beans:constructor-arg name="decisionVoters">
             <beans:list>
                 <beans:bean class="org.springframework.security.access.vote.RoleVoter"/>
             </beans:list>
-        </beans:property>
+        </beans:constructor-arg>
     </beans:bean>
 
 </beans:beans>

--- a/web-admin/src/main/webapp/WEB-INF/spring-admin-mvc-servlet.xml
+++ b/web-admin/src/main/webapp/WEB-INF/spring-admin-mvc-servlet.xml
@@ -27,7 +27,7 @@
         <property name="formatPattern" value="${log.file.pattern}"/>
     </bean>
 
-    <bean id="freemarkerConfig" class="org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer">
+    <bean id="freemarkerConfig" class="org.openhubframework.openhub.admin.web.DefaultFreeMarkerConfigurer">
         <property name="templateLoaderPath" value="/freemarker/"/>
         <property name="freemarkerSettings">
             <props>
@@ -65,7 +65,7 @@
     <!-- error codes catalog -->
     <util:map id="errorCodesCatalog" value-type="java.util.List">
         <entry key="Core" >
-            <bean id="errorCoreCodes" class="org.openhubframework.openhub.modules.ErrorEnum" factory-method="values" />
+            <bean class="org.openhubframework.openhub.modules.ErrorEnum" factory-method="values" />
         </entry>
     </util:map>
 

--- a/web-admin/src/main/webapp/WEB-INF/web.xml
+++ b/web-admin/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/javaee/web-app_2_4.xsd"
-         version="2.4">
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
 
     <display-name>OpenHub integration server</display-name>
     <description>OpenHub integration server</description>

--- a/web-admin/src/main/webapp/freemarker/lib/utils.ftl
+++ b/web-admin/src/main/webapp/freemarker/lib/utils.ftl
@@ -30,7 +30,7 @@
                                                                            alt="OpenHub"/></a></span>
         <span class="headline"><@spring.message "index.integrationFramework"/></span>
         <@sec.authorize access="isAuthenticated()">
-            <span class="logout"><a href="${rootContext}/j_spring_security_logout"
+            <span class="logout"><a href="${rootContext}/logout"
                     ><@spring.message "login.text.logout"/> | <@sec.authentication property="principal.username"/></a>
             </span>
         </@sec.authorize>

--- a/web-admin/src/main/webapp/freemarker/login.ftl
+++ b/web-admin/src/main/webapp/freemarker/login.ftl
@@ -4,7 +4,7 @@
 
 <div id="login">
     <h1><@spring.message "login.title"/></h1>
-    <form id="loginForm" method="post" action="${rootContext}/j_spring_security_check">
+    <form id="loginForm" method="post" action="${rootContext}/login">
         <input id="user" name="username" type="text" placeholder="<@spring.message "login.input.username"/>" tabindex="1" />
         <input id="pass" name="password" type="password" placeholder="<@spring.message "login.input.password"/>" tabindex="2" />
         <input type="submit" name="submit" value="<@spring.message "login.btn.login"/>" />


### PR DESCRIPTION
# Changes - upgrade description
- upgrade Java to version 7 (updated .travis.yml definition)
- camel to 2.17.3 (last stable version which supports Java7) - http://camel.apache.org/camel-2170-release.html
- spring to 4.3.4.RELEASE - compatible with camel version
- spring-ws compatible with spring version (2.2.2)
- upgrade spring-security to compatible version 4.1.3
	- csrf definition (http://docs.spring.io/spring-security/site/migrate/current/3-to-4/html5/migrate-3-to-4-xml.html#m3to4-xmlnamespace-csrf)
	- login/logout processing url (http://docs.spring.io/spring-security/site/migrate/current/3-to-4/html5/migrate-3-to-4-xml.html#m3to4-xmlnamespace-form-login)
	- use-expressions attribute (http://docs.spring.io/spring-security/site/migrate/current/3-to-4/html5/migrate-3-to-4-xml.html#m3to4-xmlnamespace-http)
	- see detail: http://docs.spring.io/spring-security/site/migrate/current/3-to-4/html5/migrate-3-to-4-xml.html#m3to4-xmlnamespace-defaults
- hibernate to last stable 5.1.x which supports Java7
- last stable version of slf4j -> 1.7.21
- last stable version of junit -> 4.12
- updated javadoc references
- c3p0:c3p0 changed to com.mchange:c3p0, version increased to the last stable version
- changed version of PMD and findbugs plugins
- updated version of postgre dependency
- updated freemarker dependency (compatible version with spring MVC)
	- created custom freemarker configurer to define ObjectWrapper to avoid exception (Custom EL functions won't be loaded because no ObjectWarpper was specified)
- **refactored using deprecated API**
	- Spring (_TransactionConfiguration_ annotation for tests, it is auto-detect automatically)
	- Camel (_Property_ -> _ExchangeProperty_)

Thera are few tests which are failing with new version of camel. **These tests will be refactored.**