### PR TITLE
Changed OpenHub Developers mail group.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ after_success:
   - .utility/push-javadoc-to-gh-pages.sh
 notifications:
   email:
-    - openhub@openwise.cz
+    - openhub_dev@openwise.cz
 sudo: false


### PR DESCRIPTION
Newly registered mail address added for travis notifications. This mail group contains all OpenHub core developers.

Issue: OHFJIRA-3