### PR TITLE
Added new message state IN_QUEUE to improve cluster support

### DIFF
--- a/common/src/test/java/org/openhubframework/openhub/common/converter/DataTypeConverterTest.java
+++ b/common/src/test/java/org/openhubframework/openhub/common/converter/DataTypeConverterTest.java
@@ -16,9 +16,7 @@
 
 package org.openhubframework.openhub.common.converter;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
@@ -87,7 +85,8 @@ public class DataTypeConverterTest {
     @Test
     public void testFile() throws ParseException {
         assertConvertFrom(TypeConverterEnum.FILE, "", new File(""));
-        String fileStr = "/Volumes/Obelix/projects";
+        String fileStr = File.pathSeparator + "Volumes" + File.pathSeparator + "Obelix" + File.pathSeparator
+                + "projects";
         assertConvertFrom(TypeConverterEnum.FILE, fileStr, new File(fileStr));
         assertConvertToString(TypeConverterEnum.FILE, new File(fileStr), fileStr);
     }

--- a/components/src/main/java/org/openhubframework/openhub/component/asynchchild/AsynchChildProducer.java
+++ b/components/src/main/java/org/openhubframework/openhub/component/asynchchild/AsynchChildProducer.java
@@ -71,7 +71,7 @@ public class AsynchChildProducer extends DefaultProducer {
         final AsynchChildEndpoint endpoint = (AsynchChildEndpoint) getEndpoint();
 
         String correlationId = (StringUtils.isNotEmpty(endpoint.getCorrelationId())
-                                ? endpoint.getCorrelationId() : generateCorrelationId());
+                ? endpoint.getCorrelationId() : generateCorrelationId());
 
         LOG.debug("Creates child message from " + (parentMsg != null ? "synchronous" : "asynchronous") + " message.");
 
@@ -86,7 +86,7 @@ public class AsynchChildProducer extends DefaultProducer {
             @Override
             public String getSystemName() {
                 return StringUtils.isNotEmpty(endpoint.getSourceSystem())
-                       ? endpoint.getSourceSystem() : DEFAULT_EXTERNAL_SYSTEM;
+                        ? endpoint.getSourceSystem() : DEFAULT_EXTERNAL_SYSTEM;
             }
         };
 
@@ -128,20 +128,20 @@ public class AsynchChildProducer extends DefaultProducer {
     /**
      * Creates the {@link Message} object that represents asynchronous message to next step processing.
      *
-     * @param service       the calling service
+     * @param service        the calling service
      * @param externalSystem the external system
-     * @param operationName the name of operation
-     * @param payload       the original payload
-     * @param objectId      the object ID
+     * @param operationName  the name of operation
+     * @param payload        the original payload
+     * @param objectId       the object ID
      * @return the {@link Message} object that represents asynchronous message to next step processing
      */
     private Message createNewMessage(ServiceExtEnum service, ExternalSystemExtEnum externalSystem,
-            String operationName, String payload, String objectId) {
+                                     String operationName, String payload, String objectId) {
 
         Date currDate = DateTime.now().toDate();
 
         Message msg = new Message();
-        msg.setState(MsgStateEnum.PROCESSING);
+        msg.setState(MsgStateEnum.NEW);
         msg.setStartProcessTimestamp(currDate);
         msg.setCorrelationId(""); // will be set later
         msg.setLastUpdateTimestamp(currDate);

--- a/components/src/test/java/org/openhubframework/openhub/component/asynchchild/AsynchChildComponentTest.java
+++ b/components/src/test/java/org/openhubframework/openhub/component/asynchchild/AsynchChildComponentTest.java
@@ -16,10 +16,7 @@
 
 package org.openhubframework.openhub.component.asynchchild;
 
-import static org.hamcrest.CoreMatchers.endsWith;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 import java.util.Date;
@@ -141,7 +138,7 @@ public class AsynchChildComponentTest extends AbstractComponentsDbTest {
 
         Message msgDB = em.find(Message.class, asynchMsg.getMsgId());
         assertThat(msgDB, notNullValue());
-        assertThat(msgDB.getState(), is(MsgStateEnum.PROCESSING));
+        assertThat(msgDB.getState(), is(MsgStateEnum.NEW));
     }
 
     @Test
@@ -167,7 +164,7 @@ public class AsynchChildComponentTest extends AbstractComponentsDbTest {
 
         Message msgDB = em.find(Message.class, asynchMsg.getMsgId());
         assertThat(msgDB, notNullValue());
-        assertThat(msgDB.getState(), is(MsgStateEnum.PROCESSING));
+        assertThat(msgDB.getState(), is(MsgStateEnum.NEW));
     }
 
     @Test
@@ -204,7 +201,7 @@ public class AsynchChildComponentTest extends AbstractComponentsDbTest {
 
         Message msgDB = em.find(Message.class, asynchMsg.getMsgId());
         assertThat(msgDB, notNullValue());
-        assertThat(msgDB.getState(), is(MsgStateEnum.PROCESSING));
+        assertThat(msgDB.getState(), is(MsgStateEnum.NEW));
     }
 
     private void createAsynchRoute() throws Exception {

--- a/core-api/src/main/java/org/openhubframework/openhub/api/asynch/AsynchConstants.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/asynch/AsynchConstants.java
@@ -16,8 +16,6 @@
 
 package org.openhubframework.openhub.api.asynch;
 
-import static org.openhubframework.openhub.api.configuration.CoreProps.ASYNCH_CONCURRENT_CONSUMERS;
-
 import org.openhubframework.openhub.api.asynch.model.CallbackResponse;
 import org.openhubframework.openhub.api.entity.EntityTypeExtEnum;
 import org.openhubframework.openhub.api.entity.Message;
@@ -160,9 +158,7 @@ public final class AsynchConstants {
     /**
      * URI for asynchronous message processing (with SEDA).
      */
-    public static final String URI_ASYNC_MSG = "seda:asynch_message_route"
-            + "?concurrentConsumers={{" + ASYNCH_CONCURRENT_CONSUMERS + "}}&waitForTaskToComplete=Never"
-            + "&blockWhenFull=true&queueFactory=#" + PRIORITY_QUEUE_FACTORY;
+    public static final String URI_ASYNC_MSG = "direct:asyncProcessingIn";
 
     /**
      * URI of the route that makes post-processing after OK message.

--- a/core-api/src/main/java/org/openhubframework/openhub/api/asynch/msg/ChildMessage.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/asynch/msg/ChildMessage.java
@@ -18,17 +18,13 @@ package org.openhubframework.openhub.api.asynch.msg;
 
 import java.util.Date;
 import java.util.UUID;
-
 import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.openhubframework.openhub.api.entity.BindingTypeEnum;
-import org.openhubframework.openhub.api.entity.EntityTypeExtEnum;
-import org.openhubframework.openhub.api.entity.Message;
-import org.openhubframework.openhub.api.entity.MsgStateEnum;
-import org.openhubframework.openhub.api.entity.ServiceExtEnum;
 import org.springframework.util.Assert;
+
+import org.openhubframework.openhub.api.entity.*;
 
 
 /**
@@ -123,7 +119,7 @@ public final class ChildMessage {
         Message msg = new Message();
 
         // new fields
-        msg.setState(MsgStateEnum.PROCESSING);
+        msg.setState(MsgStateEnum.NEW);
         msg.setStartProcessTimestamp(currDate);
         msg.setCorrelationId(UUID.randomUUID().toString());
         msg.setLastUpdateTimestamp(currDate);

--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/Message.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/Message.java
@@ -106,6 +106,9 @@ public class Message implements HumanReadable {
     @Column(name = "start_process_timestamp", nullable = true)
     private Date startProcessTimestamp;
 
+    @Column(name = "start_in_queue_timestamp", nullable = true)
+    private Date startInQueueTimestamp;
+
     @Column(name = "failed_count", nullable = false)
     private int failedCount;
 
@@ -438,6 +441,22 @@ public class Message implements HumanReadable {
         Assert.notNull(startProcessTimestamp, "the processTimestamp must not be null");
 
         this.startProcessTimestamp = startProcessTimestamp != null ? new Date(startProcessTimestamp.getTime()) : null;
+    }
+
+    /**
+     * Gets timestamp when the message was added into queue for processing.
+     *
+     * @return time when the message was added into queue for processing
+     */
+    @Nullable
+    public Date getStartInQueueTimestamp() {
+        return startInQueueTimestamp != null ? new Date(startInQueueTimestamp.getTime()) : null;
+    }
+
+    public void setStartInQueueTimestamp(Date startInQueueTimestamp){
+        Assert.notNull(startInQueueTimestamp, "startInQueueTimestamp must not be null");
+
+        this.startInQueueTimestamp = startInQueueTimestamp;
     }
 
     /**

--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/MsgStateEnum.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/MsgStateEnum.java
@@ -34,6 +34,11 @@ public enum MsgStateEnum {
     OK,
 
     /**
+     * Message is in queue and waiting for free thread for processing.
+     */
+    IN_QUEUE,
+
+    /**
      * Message is just processing.
      */
     PROCESSING,

--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
@@ -16,9 +16,7 @@
 
 package org.openhubframework.openhub.spi.msg;
 
-import static org.openhubframework.openhub.api.asynch.AsynchConstants.CUSTOM_DATA_PROP;
-import static org.openhubframework.openhub.api.asynch.AsynchConstants.EXCEPTION_ERROR_CODE;
-import static org.openhubframework.openhub.api.asynch.AsynchConstants.MSG_HEADER;
+import static org.openhubframework.openhub.api.asynch.AsynchConstants.*;
 
 import java.util.Collection;
 import java.util.List;
@@ -141,6 +139,22 @@ public interface MessageService {
     void setStateFailed(Message msg, ErrorExtEnum errCode, String errDesc);
 
     /**
+     * Set state {@link MsgStateEnum#IN_QUEUE} on {@link Message} under database lock.
+     *
+     * @param message message on which will be state changed
+     * @return {@code true} - state was successfully changed, {@code false} - otherwise
+     */
+    boolean setStateInQueueForLock(Message message);
+
+    /**
+     * Set state {@link MsgStateEnum#PROCESSING} on {@link Message} under database lock.
+     *
+     * @param message message on which will be state changed
+     * @return {@code true} - state was successfully changed, {@code false} - otherwise
+     */
+    boolean setStateProcessingForLock(Message message);
+
+    /**
      * Finds message by message ID.
      *
      * @param msgId the message ID
@@ -234,4 +248,22 @@ public interface MessageService {
      * @param funnelCompId the funnel component ID
      */
     void setFunnelComponentId(Message msg, String funnelCompId);
+
+    /**
+     * Finds ONE message in state {@link MsgStateEnum#POSTPONED}.
+     *
+     * @param interval Interval (in seconds) after that can be postponed message processed again
+     * @return message or null if there is no any message
+     */
+    @Nullable
+    Message findPostponedMessage(Seconds interval);
+
+    /**
+     * Finds ONE message in state {@link MsgStateEnum#PARTLY_FAILED}.
+     *
+     * @param interval Interval (in seconds) between two tries of partly failed messages.
+     * @return message or null if there is no any message
+     */
+    @Nullable
+    Message findPartlyFailedMessage(Seconds interval);
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -63,6 +63,12 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+        </dependency>
+
+
+        <dependency>
             <groupId>jcifs</groupId>
             <artifactId>jcifs</artifactId>
         </dependency>

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchInMessageRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchInMessageRoute.java
@@ -16,10 +16,7 @@
 
 package org.openhubframework.openhub.core.common.asynch;
 
-import static org.openhubframework.openhub.api.asynch.AsynchConstants.ERR_CALLBACK_RES_PROP;
-import static org.openhubframework.openhub.api.asynch.AsynchConstants.OPERATION_HEADER;
-import static org.openhubframework.openhub.api.asynch.AsynchConstants.SERVICE_HEADER;
-import static org.openhubframework.openhub.api.asynch.AsynchConstants.URI_ASYNCH_IN_MSG;
+import static org.openhubframework.openhub.api.asynch.AsynchConstants.*;
 
 import java.sql.SQLException;
 import java.util.List;

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageTransformer.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageTransformer.java
@@ -17,7 +17,6 @@
 package org.openhubframework.openhub.core.common.asynch.msg;
 
 import java.util.Date;
-
 import javax.annotation.Nullable;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
@@ -30,19 +29,16 @@ import org.apache.camel.Header;
 import org.apache.camel.component.spring.ws.SpringWebserviceMessage;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.openhubframework.openhub.api.asynch.AsynchConstants;
-import org.openhubframework.openhub.api.asynch.model.TraceHeader;
-import org.openhubframework.openhub.api.asynch.model.TraceIdentifier;
-import org.openhubframework.openhub.api.entity.EntityTypeExtEnum;
-import org.openhubframework.openhub.api.entity.ExternalSystemExtEnum;
-import org.openhubframework.openhub.api.entity.Message;
-import org.openhubframework.openhub.api.entity.MsgStateEnum;
-import org.openhubframework.openhub.api.entity.ServiceExtEnum;
-import org.openhubframework.openhub.core.common.asynch.AsynchInMessageRoute;
-import org.openhubframework.openhub.core.common.asynch.TraceHeaderProcessor;
 import org.springframework.util.Assert;
 import org.springframework.ws.soap.saaj.SaajSoapMessage;
 import org.springframework.xml.transform.StringResult;
+
+import org.openhubframework.openhub.api.asynch.AsynchConstants;
+import org.openhubframework.openhub.api.asynch.model.TraceHeader;
+import org.openhubframework.openhub.api.asynch.model.TraceIdentifier;
+import org.openhubframework.openhub.api.entity.*;
+import org.openhubframework.openhub.core.common.asynch.AsynchInMessageRoute;
+import org.openhubframework.openhub.core.common.asynch.TraceHeaderProcessor;
 
 
 /**
@@ -106,7 +102,7 @@ public final class MessageTransformer {
         Date currDate = new Date();
 
         Message msg = new Message();
-        msg.setState(MsgStateEnum.PROCESSING);
+        msg.setState(MsgStateEnum.NEW);
         msg.setStartProcessTimestamp(currDate);
 
         // params from trace header

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/queue/MessagePollExecutor.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/queue/MessagePollExecutor.java
@@ -40,6 +40,7 @@ import org.openhubframework.openhub.api.entity.Message;
 import org.openhubframework.openhub.api.exception.IntegrationException;
 import org.openhubframework.openhub.api.exception.InternalErrorEnum;
 import org.openhubframework.openhub.api.exception.LockFailureException;
+import org.openhubframework.openhub.core.common.asynch.AsynchMessageRoute;
 import org.openhubframework.openhub.core.common.asynch.LogContextHelper;
 import org.openhubframework.openhub.core.common.event.AsynchEventHelper;
 import org.openhubframework.openhub.spi.msg.MessageService;
@@ -76,7 +77,7 @@ public class MessagePollExecutor implements Runnable {
     private ConfigurationItem<Seconds> postponedIntervalWhenFailed;
 
     // note: this is because of setting different target URI for tests
-    private String targetURI = AsynchConstants.URI_ASYNC_MSG;
+    private String targetURI = AsynchMessageRoute.URI_ASYNC_PROCESSING_MSG;
 
     @Override
     public void run() {

--- a/core/src/main/java/org/openhubframework/openhub/core/common/dao/DbConst.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/dao/DbConst.java
@@ -24,11 +24,16 @@ package org.openhubframework.openhub.core.common.dao;
  */
 public final class DbConst {
 
-    private DbConst() {
-    }
-
     /**
      * Default database unit name of Hibernate.
      */
     public static final String UNIT_NAME = "OpenHub";
+
+    /**
+     * Default transaction manager name.
+     */
+    public static final String TRANSACTION_MANAGER_NAME = "jpaTxManager";
+
+    private DbConst() {
+    }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
@@ -110,15 +110,25 @@ public interface MessageDao {
     Message findPostponedMessage(Seconds interval);
 
     /**
-     * Updates message (set start timestamp of processing) - gets lock for message.
+     * Updates {@link Message} into state {@link MsgStateEnum#PROCESSING} (set start timestamp of processing)
+     * - gets lock for message.
      *
      * @param msg the message
-     * @return true when update was successful otherwise false
+     * @return {@code true} when update was successful otherwise {@code false}
      */
-    Boolean updateMessageForLock(Message msg);
+    boolean updateMessageProcessingUnderLock(Message msg);
 
     /**
-     * Finds processing messages.
+     * Updates {@link Message} into state {@link MsgStateEnum#IN_QUEUE} (set start timestamp in queue)
+     * - gets lock for message.
+     *
+     * @param msg the message
+     * @return {@code true} when update was successful otherwise {@code false}
+     */
+    boolean updateMessageInQueueUnderLock(Message msg);
+
+    /**
+     * Finds processing messages to repair process.
      *
      * @param interval Interval (in seconds) after that processing messages are probably in dead-lock
      * @return list of messages

--- a/core/src/main/resources/db/db_schema_postgreSql_2_0_0.sql
+++ b/core/src/main/resources/db/db_schema_postgreSql_2_0_0.sql
@@ -1,0 +1,6 @@
+--
+-- DB increment script for version 2.0.0
+--
+
+-- adding start_in_queue_timestamp
+alter table message add column start_in_queue_timestamp timestamp null;

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRouteConfirmTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRouteConfirmTest.java
@@ -117,7 +117,7 @@ public class AsynchMessageRouteConfirmTest extends AbstractCoreDbTest {
         Date currDate = new Date();
 
         msg = new Message();
-        msg.setState(MsgStateEnum.PROCESSING);
+        msg.setState(MsgStateEnum.IN_QUEUE);
         msg.setMsgTimestamp(currDate);
         msg.setReceiveTimestamp(currDate);
         msg.setSourceSystem(ExternalSystemTestEnum.CRM);

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/db/PartlyFailedMessagesPoolDbTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/db/PartlyFailedMessagesPoolDbTest.java
@@ -16,9 +16,7 @@
 
 package org.openhubframework.openhub.core.common.asynch.db;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 import java.util.Date;
@@ -33,14 +31,14 @@ import org.openhubframework.openhub.api.entity.Message;
 import org.openhubframework.openhub.api.entity.MsgStateEnum;
 import org.openhubframework.openhub.core.AbstractCoreDbTest;
 import org.openhubframework.openhub.core.common.asynch.queue.MessagesPool;
-import org.openhubframework.openhub.core.common.asynch.queue.MessagesPoolDbImpl;
+import org.openhubframework.openhub.core.common.asynch.queue.MessagesPoolImpl;
 import org.openhubframework.openhub.core.configuration.FixedConfigurationItem;
 import org.openhubframework.openhub.test.data.ExternalSystemTestEnum;
 import org.openhubframework.openhub.test.data.ServiceTestEnum;
 
 
 /**
- * Test suite for {@link MessagesPoolDbImpl}.
+ * Test suite for {@link MessagesPoolImpl}.
  *
  * @author Petr Juza
  */
@@ -63,8 +61,9 @@ public class PartlyFailedMessagesPoolDbTest extends AbstractCoreDbTest {
 
         Message nextMsg = messagesPool.getNextMessage();
         assertThat(nextMsg, notNullValue());
-        assertThat(nextMsg.getState(), is(MsgStateEnum.PROCESSING));
-        assertThat(nextMsg.getStartProcessTimestamp(), notNullValue());
+        assertThat(nextMsg.getState(), is(MsgStateEnum.IN_QUEUE));
+        assertThat(nextMsg.getStartProcessTimestamp(), nullValue());
+        assertThat(nextMsg.getStartInQueueTimestamp(), notNullValue());
         assertThat(nextMsg.getLastUpdateTimestamp(), notNullValue());
 
         // try again

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/queue/MessagePollExecutorTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/queue/MessagePollExecutorTest.java
@@ -147,15 +147,15 @@ public class MessagePollExecutorTest extends AbstractCoreDbTest {
         // verify messages
         Message msg = findMessage("1234_4567");
         assertThat(msg, notNullValue());
-        assertThat(msg.getState(), is(MsgStateEnum.PROCESSING));
+        assertThat(msg.getState(), is(MsgStateEnum.IN_QUEUE));
 
         msg = findMessage("1234_4567_8");
         assertThat(msg, notNullValue());
-        assertThat(msg.getState(), is(MsgStateEnum.PROCESSING));
+        assertThat(msg.getState(), is(MsgStateEnum.IN_QUEUE));
 
         msg = findMessage("1234_4567_9");
         assertThat(msg, notNullValue());
-        assertThat(msg.getState(), is(MsgStateEnum.PROCESSING));
+        assertThat(msg.getState(), is(MsgStateEnum.IN_QUEUE));
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/repair/RepairMessageServiceDbImplTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/repair/RepairMessageServiceDbImplTest.java
@@ -16,11 +16,12 @@
 
 package org.openhubframework.openhub.core.common.asynch.repair;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
@@ -40,7 +41,6 @@ import org.openhubframework.openhub.core.AbstractCoreDbTest;
 import org.openhubframework.openhub.core.common.dao.MessageDao;
 import org.openhubframework.openhub.core.configuration.FixedConfigurationItem;
 
-
 /**
  * Tests {@link RepairMessageServiceDbImpl}
  */
@@ -57,7 +57,10 @@ public class RepairMessageServiceDbImplTest extends AbstractCoreDbTest {
 
     @Test
     public void testRepairProcessingMessagesMany() throws Exception {
-        Message[] messages = createAndSaveMessages(119, MsgStateEnum.PROCESSING);
+        List<Message> messages = new LinkedList<>();
+        messages.addAll(Arrays.asList(createAndSaveMessages(70, MsgStateEnum.PROCESSING)));
+        messages.addAll(Arrays.asList(createAndSaveMessages(30, MsgStateEnum.NEW)));
+        messages.addAll(Arrays.asList(createAndSaveMessages(28, MsgStateEnum.IN_QUEUE)));
 
         // 3 times because MAX_MESSAGES_IN_ONE_QUERY=50
         messageService.repairProcessingMessages();

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,11 @@
                 <artifactId>commons-io</artifactId>
                 <version>2.4</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.0</version>
+            </dependency>
 
 
             <!-- monitoring-->
@@ -545,7 +550,7 @@
                                 <goal>jar</goal>
                             </goals>
                         </execution>
-                    </executions>                    
+                    </executions>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
New state IN_QUEUE tells that message was added into SEDA queue.

There are the following main two reasons why to do it:

- to be able separate two states: 1) when message is waiting in SEDA queue and 2) when is being processed
- ensure that one message is being processed in just one node only in the cluster

Issue: https://openhubframework.atlassian.net/browse/OHFJIRA-19