### PR TITLE
Configured coverage report generation via TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,16 @@ env:
 before_install:
   - chmod +x .utility/push-javadoc-to-gh-pages.sh 
   - chmod +x .utility/publish-artifacts.sh 
-install: mvn install -DskipTests=true -q
-script: mvn test javadoc:aggregate -Dlogging.level.org.openhubframework.openhub=INFO
+install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -q
+script: mvn test javadoc:aggregate jacoco:report -Dlogging.level.org.openhubframework.openhub=INFO
 after_success:  
   - .utility/push-javadoc-to-gh-pages.sh
   - .utility/publish-artifacts.sh
+  # 'coveralls:report' goal is responsible for updating coverall.io stats once travisCI build completes  
+  - mvn coveralls:report  
+cache:
+  directories:
+    - $HOME/.m2  
 notifications:
   email:
     - openhub_dev@openwise.cz

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Welcome to OpenHub Framework [![Build Status](https://travis-ci.org/OpenWiseSolutions/openhub-framework.svg?branch=develop)](https://travis-ci.org/OpenWiseSolutions/openhub-framework) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.openhubframework/openhub/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.openhubframework/openhub)
+# Welcome to OpenHub Framework 
+[![Build Status](https://travis-ci.org/OpenWiseSolutions/openhub-framework.svg?branch=develop)](https://travis-ci.org/OpenWiseSolutions/openhub-framework) [![Coverage Status](https://coveralls.io/repos/github/OpenWiseSolutions/openhub-framework/badge.svg?branch=develop)](https://coveralls.io/github/OpenWiseSolutions/openhub-framework?branch=develop) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.openhubframework/openhub/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.openhubframework/openhub)
 
 **ESB made by developers for developers**
 

--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,9 @@
                     <!-- be careful if upgrade, Travis has problem with higher version -->
                     <version>2.18</version>
                     <configuration>
-                        <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+                        <!-- Sets the VM argument line used when unit tests are run. -->
+                        <!-- from jacoco doc, add jacoco java agent -->
+                        <argLine>${argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
                     </configuration>
                 </plugin>
 
@@ -543,6 +545,37 @@
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
+                
+                <plugin>
+                    <groupId>org.eluder.coveralls</groupId>
+                    <artifactId>coveralls-maven-plugin</artifactId>
+                    <version>4.3.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.7.6.201602180812</version>
+                    <configuration>
+                        <excludes>
+                            <exclude>**/model/**/*</exclude>
+                        </excludes>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <phase>prepare-package</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -617,6 +650,16 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
             
             <plugin>


### PR DESCRIPTION
To increase quality of code coverage report will be generated by TravisCI. `maven-surefire-plugin` configuration was updated with `{argLine}` to propagate `jacoco` [javaagent](http://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html).

See [first coverage report](https://coveralls.io/github/OpenWiseSolutions/openhub-framework) => we should increase coverage for core functions, especially services and DAO layer.

- updated `.travis.yml` to export `jacoco` report to coveralls server
- added cache of `.m2` maven folder for faster builds
- configure `jacoco` (and also surefire test plugin) to generate report for multi-module structure (generated classes must be excluded, for not all `**/model/**/*` packages)
- added badge to `README.md` file

Issue: [OHFJIRA-31](https://openhubframework.atlassian.net/browse/OHFJIRA-31)