### PR TITLE
Add spring-boot-configuration-processor to generate OHF configuration meta-data.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,13 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- Enabled configuration properties in OHF classes -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-configuration-processor</artifactId>
+                <version>${spring-boot.version}</version>
+                <optional>true</optional>
+            </dependency>
 
             <!-- persistence -->
             <dependency>
@@ -305,6 +312,11 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
+        </dependency>
+        <!-- enabled configuration properties in OHF classes -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
# What is benefit?

- autocompletion in config properties
- cross-reference among source code and property files

![Supported with IDE](http://www.sothawo.com/wp-content/uploads/2015/06/sbcfg01.png "Benefit of meta-model - autocompletion")

[How to configure](http://www.mdoninger.de/2015/05/16/completion-for-custom-properties-in-spring-boot.html) overview.

See:
- http://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html
- http://www.sothawo.com/2015/06/using-spring-boot-configuration-properties-in-your-own-classes

Issue: [OHFJIRA-34](https://openhubframework.atlassian.net/browse/OHFJIRA-34)