### PR TITLE
Activation by default Maven profile and other profiles does not work properly.

### DIFF
--- a/admin-console/pom.xml
+++ b/admin-console/pom.xml
@@ -26,9 +26,11 @@
             <!-- Profile which is used to clean all admin console libs -->
             <id>full-clean</id>
 
-            <!-- Activated by default -->
+            <!-- activated by default -->
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!skipDefault</name>
+                </property>
             </activation>
             
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,11 @@
             <!-- Profile which is used to build OHF with all modules (all-in-one) -->
             <id>full-build</id>
 
-            <!-- Activated by default -->
+            <!-- activated by default -->
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!skipDefault</name>
+                </property>
             </activation>
 
             <modules>

--- a/web-admin/pom.xml
+++ b/web-admin/pom.xml
@@ -98,6 +98,14 @@
         <profile>
             <!-- Profile which is used to build OHF with all modules (all-in-one) -->
             <id>full-build</id>
+
+            <!-- activated by default -->
+            <activation>
+                <property>
+                    <name>!skipDefault</name>
+                </property>
+            </activation>
+            
             <dependencies>
                 <!-- Admin console -->
                 <dependency>


### PR DESCRIPTION
Unfortunately there’s no straight forward way of [mixing profiles](https://openhubframework.atlassian.net/wiki/display/OHF/Maven+and+Spring#MavenandSpring-Mavenprofiles) marked as `activeByDefault` with other profiles.
The simplest solution with minimal impact would be to rewrite the `activeByDefault` attribute with property `!skipDefault`, this is recommend approach for "default" profiles.

Issue: [GENERAL](http://greyfocus.com/2015/06/activebydefault-maven-other-profiles/)