### PR TITLE
BUGFIX: Form based security configuration for admin GUI does not work as expected

### DIFF
--- a/core-api/src/main/java/org/openhubframework/openhub/api/route/RouteConstants.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/route/RouteConstants.java
@@ -44,17 +44,17 @@ public final class RouteConstants {
     public static final String CAMEL_SERVLET = "CamelServlet";
 
     /**
-     * URI prefix for web services - "spring-ws" in web.xml.
+     * URI prefix for web services.
      */
     public static final String WS_URI_PREFIX = "/ws/";
 
     /**
-     * URI prefix for CamelServlet (see web.xml).
+     * URI prefix for {@code CamelServlet}.
      */
     public static final String HTTP_URI_PREFIX = "/http/";
 
     /**
-     * URI prefix for web admin GUI - "spring-admin-mvc" in web.xml.
+     * URI prefix for web admin GUI.
      */
     public static final String WEB_URI_PREFIX = "/web/admin/";
 


### PR DESCRIPTION
Fixed wrong security configuration for multiple HTTP configurer adapters.
If we have to have more than one security configurer it is necessary to split it into two adapters. The same issue occurs when we will divide spring contexts into hierarchy.

See Spring [documentation](http://docs.spring.io/spring-security/site/docs/current/reference/htmlsingle/#multiple-httpsecurity) or the same problem at [Stackoverflow](http://stackoverflow.com/a/27833237).

Issue: [OHFJIRA-41](https://openhubframework.atlassian.net/browse/OHFJIRA-41)