### PR TITLE
OHFJIRA-23: JavaEE support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,11 @@
             <id>ossrh</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>        
-    </distributionManagement>    
+    </distributionManagement>
+
+    <prerequisites>
+        <maven>3.1.0</maven>
+    </prerequisites>
 
     <modules>
         <module>common</module>

--- a/web-admin/src/main/java/org/openhubframework/openhub/OpenHubApplication.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/OpenHubApplication.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.context.web.ErrorPageFilter;
 import org.springframework.boot.context.web.SpringBootServletInitializer;
 import org.springframework.context.annotation.*;
+import org.springframework.web.WebApplicationInitializer;
 
 import org.openhubframework.openhub.api.route.CamelConfiguration;
 import org.openhubframework.openhub.common.AutoConfiguration;
@@ -72,7 +73,9 @@ import org.openhubframework.openhub.core.config.WebServiceConfig;
 @Configuration
 @ImportResource("classpath:sp_camelContext.xml")
 @PropertySource(value = {"classpath:/extensions.cfg"})
-public class OpenHubApplication extends SpringBootServletInitializer {
+// WebApplicationInitializer must be implemented directly because of Weblogic support
+// see https://docs.spring.io/spring-boot/docs/current/reference/html/howto-traditional-deployment.html#howto-weblogic
+public class OpenHubApplication extends SpringBootServletInitializer implements WebApplicationInitializer {
     
     /**
      * Sets up filter for adding context information to logging.


### PR DESCRIPTION
It is necessary to support main JavaEE and classic servlet-based java containers. Actually we have tested Tomcat (8.*) in classic and embedded version. JBoss and WebLogic is tested as well. 

Another application server such as WebSphere requires configuration of classloading due to JPA 2.1 which is not supported by container. This is necessary to configure on application server, no in application. We have some recommendation how to solve it described on [WIKI page](https://openhubframework.atlassian.net/wiki/display/OHF/Traditional+deployment).

## Changes:
- to support WebLogic then the servlet initializer must directly implements WebApplicationInitializer (even if we extend from a base class that already implements it)
- added maven version constraint

## Notes:
For **WebSphere** it is necessary to create [commonj scheduler and executor service](http://www.ibm.com/support/knowledgecenter/SS7JFU_7.0.0/com.ibm.websphere.express.doc/info/exp/asyncbns/concepts/casb_workmgr.html) (also for JavaEE servers), but it will be solved in [OHFJIRA-27](https://openhubframework.atlassian.net/browse/OHFJIRA-27) task.

Issue: [OHFJIRA-27](https://openhubframework.atlassian.net/browse/OHFJIRA-27)