### PR TITLE
Add memory-grid/cache

### DIFF
--- a/common/src/main/java/org/openhubframework/openhub/common/OpenHubPropertyConstants.java
+++ b/common/src/main/java/org/openhubframework/openhub/common/OpenHubPropertyConstants.java
@@ -33,7 +33,7 @@ public class OpenHubPropertyConstants {
      * OpenHub property prefix name used for custom properties created for OpenHub.
      * These property names should have the same prefix.
      */
-    public static final String PREFIX = "ohf";
+    public static final String PREFIX = "ohf.";
 
     private OpenHubPropertyConstants() {
         // avoid instantiation

--- a/common/src/main/java/org/openhubframework/openhub/common/Profiles.java
+++ b/common/src/main/java/org/openhubframework/openhub/common/Profiles.java
@@ -40,6 +40,11 @@ public final class Profiles {
     public static final String PROD = "prod";
 
     /**
+     * Spring profile for running OpenHub in the cluster.
+     */
+    public static final String CLUSTER = "cluster";
+
+    /**
      * Spring profile for running H2 DB.
      */
     public static final String H2 = "h2";

--- a/common/src/main/java/org/openhubframework/openhub/common/synchronization/package-info.java
+++ b/common/src/main/java/org/openhubframework/openhub/common/synchronization/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Contains class for synchronization one ore more threads by one or more values.
+ * Contains classes for synchronization one ore more threads by one or more values.
  */
 package org.openhubframework.openhub.common.synchronization;

--- a/core-api/src/main/java/org/openhubframework/openhub/api/configuration/CoreProps.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/configuration/CoreProps.java
@@ -16,6 +16,9 @@
 
 package org.openhubframework.openhub.api.configuration;
 
+import static org.openhubframework.openhub.common.OpenHubPropertyConstants.PREFIX;
+
+
 /**
  * Constants of core property names.
  *
@@ -23,8 +26,6 @@ package org.openhubframework.openhub.api.configuration;
  * @since 2.0
  */
 public class CoreProps {
-
-    public static final String PREFIX = "ohf.";
 
     /**
      * Failed count of partly fails before message will be marked as completely FAILED.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,20 @@
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
+        <!-- Cache -->
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-spring</artifactId>
+        </dependency>
+        <dependency>
+        <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+
         <!-- persistence -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/core/src/main/java/org/openhubframework/openhub/core/throttling/AbstractThrottleCounter.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/throttling/AbstractThrottleCounter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.throttling;
+
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.LocalDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
+
+import org.openhubframework.openhub.spi.throttling.ThrottleCounter;
+import org.openhubframework.openhub.spi.throttling.ThrottleScope;
+
+
+/**
+ * Abstract implementation of {@link ThrottleCounter} interface.
+ *
+ * @author Petr Juza
+ * @since 2.0
+ */
+public abstract class AbstractThrottleCounter implements ThrottleCounter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractThrottleCounter.class);
+
+    private static final int DUMP_PERIOD_SEC = 60;
+
+    private volatile LocalDateTime lastDumpTimestamp = LocalDateTime.now();
+
+    @Override
+    public final int count(ThrottleScope throttleScope, int intervalSec) {
+        Assert.notNull(throttleScope, "the throttleScope must not be null");
+        Assert.isTrue(intervalSec > 0, "the intervalSec must be positive value");
+
+        Integer count = doCount(throttleScope, intervalSec);
+
+        // make dump only once in the specified intervalSec
+        if (LOG.isDebugEnabled() && (LocalDateTime.now().minusSeconds(DUMP_PERIOD_SEC).isAfter(lastDumpTimestamp))) {
+            String cacheInfo = getCacheInfo();
+
+            if (StringUtils.isNotEmpty(cacheInfo)) {
+                LOG.debug(cacheInfo);
+            }
+
+            lastDumpTimestamp = LocalDateTime.now();
+        }
+
+        return count;
+    }
+
+    /**
+     * Counts requests for specified throttle scope and time interval.
+     *
+     * @param throttleScope the throttle scope
+     * @param intervalSec the time interval in seconds
+     * @return count of requests
+     */
+    protected abstract int doCount(ThrottleScope throttleScope, int intervalSec);
+
+    /**
+     * Returns memory info/statistics for logging.
+     *
+     * @return cache info or {@code null} if there is no info to log
+     */
+    @Nullable
+    String getCacheInfo() {
+        return null;
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/throttling/HazelcastThrottleScope.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/throttling/HazelcastThrottleScope.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.throttling;
+
+import java.io.IOException;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import org.springframework.util.Assert;
+
+import org.openhubframework.openhub.spi.throttling.ThrottleScope;
+
+
+/**
+ * Serializable version of {@link ThrottleScope} for {@link ThrottleCounterHazelcastImpl Hazelcast implementation}.
+ *
+ * @author Petr Juza
+ * @since 2.0
+ */
+public final class HazelcastThrottleScope implements DataSerializable {
+
+    private String sourceSystem;
+
+    private String serviceName;
+
+    // empty for serialization/deserialization
+    public HazelcastThrottleScope() {
+    }
+
+    HazelcastThrottleScope(ThrottleScope throttleScope) {
+        Assert.notNull(throttleScope, "the throttleScope must not be null");
+
+        this.sourceSystem = throttleScope.getSourceSystem();
+        this.serviceName = throttleScope.getServiceName();
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(sourceSystem);
+        out.writeUTF(serviceName);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        this.sourceSystem = in.readUTF();
+        this.serviceName = in.readUTF();
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/throttling/ThrottleCounterHazelcastImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/throttling/ThrottleCounterHazelcastImpl.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.throttling;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import javax.annotation.Nullable;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.AbstractEntryProcessor;
+import com.hazelcast.map.EntryProcessor;
+import org.joda.time.DateTime;
+import org.springframework.util.Assert;
+
+import org.openhubframework.openhub.spi.throttling.ThrottleCounter;
+import org.openhubframework.openhub.spi.throttling.ThrottleScope;
+
+
+/**
+ * Shared memory (aka memory grid or cache) implementation of {@link ThrottleCounter} interface
+ * by Hazelcast' {@link IMap map} and {@link EntryProcessor}.
+ * Suitable for running OpenHub in the cluster environment.
+ * <p/>
+ * Implementation prerequisites Hazelcast's map definition with the name '{@value #MAP_THROTTLING}'.
+ *
+ * @author Petr Juza
+ * @since 2.0
+ * @see HazelcastThrottleScope
+ */
+public class ThrottleCounterHazelcastImpl extends AbstractThrottleCounter {
+
+    private static final String MAP_THROTTLING = "throttling";
+
+    private final HazelcastInstance hazelcast;
+
+    public ThrottleCounterHazelcastImpl(HazelcastInstance hazelcast) {
+        Assert.notNull(hazelcast, "hazelcast must not be null");
+
+        this.hazelcast = hazelcast;
+    }
+
+    @Override
+    protected int doCount(ThrottleScope throttleScope, int intervalSec) {
+        IMap<HazelcastThrottleScope, List<Long>> map = hazelcast.getMap(MAP_THROTTLING);
+
+        Assert.notNull(map, "shared map must not be null");
+
+        HazelcastThrottleScope sharedThrottleScope = new HazelcastThrottleScope(throttleScope);
+        return (Integer) map.executeOnKey(sharedThrottleScope, new CounterEntryProcessor(intervalSec));
+    }
+
+    @Override
+    @Nullable
+    String getCacheInfo() {
+        IMap<Object, Object> map = hazelcast.getMap(MAP_THROTTLING);
+        return "Throttling Hazelcast statistics dump:\n" + map.getLocalMapStats().toString();
+    }
+
+    /**
+     * {@link EntryProcessor} for specific map entry.
+     */
+    private static class CounterEntryProcessor extends AbstractEntryProcessor<HazelcastThrottleScope, List<Long>> {
+
+        private int intervalSec;
+
+        /**
+         * Creates {@link EntryProcessor} for specific map entry.
+         *
+         * @param intervalSec the time interval in seconds
+         */
+        CounterEntryProcessor(int intervalSec) {
+            // backups are disabled for this shared map
+            super(false);
+
+            this.intervalSec = intervalSec;
+        }
+
+        @Override
+        public Object process(Map.Entry<HazelcastThrottleScope, List<Long>> entry) {
+            Integer counter = 0;
+
+            List<Long> timestamps;
+
+            if (entry.getValue() == null) {
+                timestamps = new Stack<>();
+            } else {
+                timestamps = entry.getValue();
+            }
+
+            long now = DateTime.now().getMillis();
+            long from = now - (intervalSec * 1000);
+
+            // get timestamps for specified throttling scope
+            timestamps.add(now);
+
+            // count requests for specified intervalSec
+            int lastIndex = -1;
+            for (int i = timestamps.size() - 1; i >= 0; i--) {
+                long timestamp = timestamps.get(i);
+
+                if (timestamp >= from) {
+                    counter++;
+                } else {
+                    lastIndex = i;
+                    break;
+                }
+            }
+
+            // remove old timestamps
+            if (lastIndex > 0) {
+                for (int i = 0; i <= lastIndex; i++) {
+                    timestamps.remove(0);
+                }
+            }
+
+            entry.setValue(timestamps);
+
+            return counter;
+        }
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/throttling/ThrottlingAutoConfiguration.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/throttling/ThrottlingAutoConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.throttling;
+
+import com.hazelcast.core.HazelcastInstance;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.hazelcast.HazelcastAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+
+import org.openhubframework.openhub.common.AutoConfiguration;
+import org.openhubframework.openhub.spi.throttling.ThrottleCounter;
+
+
+/**
+ * Configures throttling counter implementations.
+ * There is property '{@value #COUNTER_IMPL_PROPERTY}' that defines which built-in implementation will be used.
+ * If not defined then default {@link ThrottleCounterMemoryImpl} implementation is used.
+ *
+ * @author Petr Juza
+ * @since 2.0
+ */
+@AutoConfiguration
+@ConditionalOnMissingBean(ThrottleCounter.class)
+@EnableConfigurationProperties(ThrottlingProperties.class)
+public class ThrottlingAutoConfiguration {
+
+    private static final String COUNTER_IMPL_PROPERTY = "ohf.throttling.counter.impl";
+
+    private static final String IN_MEMORY_CLASS_NAME
+            = "org.openhubframework.openhub.core.throttling.ThrottleCounterMemoryImpl";
+
+    private static final String HAZELCAST_CLASS_NAME
+            = "org.openhubframework.openhub.core.throttling.ThrottleCounterHazelcastImpl";
+
+    @AutoConfiguration
+    @ConditionalOnProperty(name = COUNTER_IMPL_PROPERTY, matchIfMissing = true, havingValue = IN_MEMORY_CLASS_NAME)
+    public static class InMemoryConfiguration {
+
+   		@Bean
+   		public ThrottleCounterMemoryImpl inMemoryThrottlingCounter()  {
+   		    return new ThrottleCounterMemoryImpl();
+   		}
+   	}
+
+    @AutoConfiguration
+    @ConditionalOnClass(HazelcastInstance.class)
+    @AutoConfigureAfter({HazelcastAutoConfiguration.class, CacheAutoConfiguration.class})
+    @ConditionalOnProperty(name = COUNTER_IMPL_PROPERTY, havingValue = HAZELCAST_CLASS_NAME)
+   	public static class HazelcastConfiguration {
+
+        @Bean
+   		public ThrottleCounterHazelcastImpl hazelcastThrottlingCounter(HazelcastInstance hazelcast)  {
+   		    return new ThrottleCounterHazelcastImpl(hazelcast);
+   		}
+   	}
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/throttling/ThrottlingProperties.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/throttling/ThrottlingProperties.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.throttling;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import org.openhubframework.openhub.common.OpenHubPropertyConstants;
+
+
+/**
+ * Configuration properties for the throttling.
+ *
+ * @author Petr Juza
+ * @since 2.0
+ */
+@ConfigurationProperties(OpenHubPropertyConstants.PREFIX + "throttling")
+public class ThrottlingProperties {
+
+    private Counter counter;
+
+    public Counter getCounter() {
+        return counter;
+    }
+
+    public void setCounter(Counter counter) {
+        this.counter = counter;
+    }
+
+    /**
+     * throttling.counter properties
+     */
+    public static class Counter {
+
+        /**
+         * the implementation of throttling counter
+         */
+        private Class impl;
+
+        public Class getImpl() {
+            return impl;
+        }
+
+        public void setImpl(Class impl) {
+            this.impl = impl;
+        }
+    }
+}

--- a/core/src/main/resources/META-INF/spring.factories
+++ b/core/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,7 @@
 # Auto Configure
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 	org.openhubframework.openhub.core.configuration.AutoConfigurationItemProperties,\
+	org.openhubframework.openhub.core.throttling.ThrottlingAutoConfiguration,\
     org.openhubframework.openhub.core.config.ConverterAutoConfiguration
 
 # Application Listeners

--- a/core/src/main/resources/config/ohf_hazelcast.xml
+++ b/core/src/main/resources/config/ohf_hazelcast.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+  -->
+
+<!--
+    The default Hazelcast configuration for OpenHub.
+
+    See the following link for inspiration/documentation:
+    https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/resources/hazelcast-full-example.xml
+-->
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.5.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <group>
+        <name>dev</name>
+        <password>dev-pass</password>
+    </group>
+    <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+    <network>
+        <port auto-increment="true" port-count="100">5701</port>
+        <outbound-ports>
+            <!--
+            Allowed port range when connecting to other nodes.
+            0 or * means use system provided port.
+            -->
+            <ports>0</ports>
+        </outbound-ports>
+        <join>
+            <multicast enabled="true">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
+        </join>
+    </network>
+
+    <!--
+        Distributed map for counting throttling.
+        Configuration has several interesting points - we need computation as fast as possible, accuracy is not crucial:
+            - no backups
+            - eviction-policy = Least Recently Used)
+            - merge policy = entry with the latest update wins
+    -->
+    <map name="throttling">
+        <!--
+           Data type that will be used for storing recordMap.
+           Possible values:
+           BINARY (default): keys and values will be stored as binary data
+           OBJECT : values will be stored in their object forms
+           NATIVE : values will be stored in non-heap region of JVM
+        -->
+        <in-memory-format>OBJECT</in-memory-format>
+
+        <!--
+            Number of backups. If 1 is set as the backup-count for example,
+            then all entries of the map will be copied to another JVM for
+            fail-safety. 0 means no backup.
+        -->
+        <backup-count>0</backup-count>
+        <!--
+            Number of async backups. 0 means no backup.
+        -->
+        <async-backup-count>0</async-backup-count>
+        <!--
+			Maximum number of seconds for each entry to stay in the map. Entries that are
+			older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+			will get automatically evicted from the map.
+			Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+		-->
+        <time-to-live-seconds>0</time-to-live-seconds>
+        <!--
+			Maximum number of seconds for each entry to stay idle in the map. Entries that are
+			idle(not touched) for more than <max-idle-seconds> will get
+			automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+			Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+		-->
+        <max-idle-seconds>300</max-idle-seconds>
+        <!--
+            Valid values are:
+            NONE (no eviction),
+            LRU (Least Recently Used),
+            LFU (Least Frequently Used).
+            NONE is the default.
+        -->
+        <eviction-policy>LRU</eviction-policy>
+        <!--
+            Maximum size of the map. When max size is reached,
+            map is evicted based on the policy defined.
+            Any integer between 0 and Integer.MAX_VALUE. 0 means
+            Integer.MAX_VALUE. Default is 0.
+        -->
+        <max-size policy="PER_NODE">0</max-size>
+        <!--
+            When max. size is reached, specified percentage of
+            the map will be evicted. Any integer between 0 and 100.
+            If 25 is set for example, 25% of the entries will
+            get evicted.
+        -->
+        <eviction-percentage>10</eviction-percentage>
+        <!--
+            Minimum time in milliseconds which should pass before checking
+            if a partition of this map is evictable or not.
+            Default value is 100 millis.
+        -->
+        <min-eviction-check-millis>100</min-eviction-check-millis>
+        <!--
+            While recovering from split-brain (network partitioning),
+            map entries in the small cluster will merge into the bigger cluster
+            based on the policy set here. When an entry merge into the
+            cluster, there might an existing entry with the same key already.
+            Values of these entries might be different for that same key.
+            Which value should be set for the key? Conflict is resolved by
+            the policy set here. Default policy is PutIfAbsentMapMergePolicy
+
+            There are built-in merge policies such as
+            com.hazelcast.map.merge.PassThroughMergePolicy; entry will be overwritten if merging entry exists for the key.
+            com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+            com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+            com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+        -->
+        <merge-policy>com.hazelcast.map.merge.LatestUpdateMapMergePolicy</merge-policy>
+
+    </map>
+
+    <serialization>
+        <portable-version>0</portable-version>
+    </serialization>
+
+    <services enable-defaults="true"/>
+
+</hazelcast>

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceTest.java
@@ -80,6 +80,20 @@ public class MessageServiceTest extends AbstractCoreDbTest {
     }
 
     @Test
+    public void testSetStateInQueueForLock() throws Exception {
+        MessageCallback processor = new MessageCallback() {
+            @Override
+            public void beforeInsert(Message msg, int order) throws Exception {
+                messageService.setStateInQueueForLock(msg);
+            }
+        };
+
+        assertSetWrongState(MsgStateEnum.FAILED, processor);
+        assertSetWrongState(MsgStateEnum.PROCESSING, processor);
+        assertSetState(MsgStateEnum.NEW, processor, MsgStateEnum.IN_QUEUE);
+    }
+
+    @Test
     public void testSetStateWaitingForResponse() throws Exception {
         MessageCallback processor = new MessageCallback() {
             @Override

--- a/core/src/test/java/org/openhubframework/openhub/core/throttling/AbstractThrottleCounterTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/throttling/AbstractThrottleCounterTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.throttling;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.openhubframework.openhub.spi.throttling.ThrottleCounter;
+import org.openhubframework.openhub.spi.throttling.ThrottleScope;
+
+
+/**
+ * Parent class for testing {@link ThrottleCounter} implementations.
+ *
+ * @author Petr Juza
+ * @since 2.0
+ */
+abstract class AbstractThrottleCounterTest {
+
+    /**
+     * Checks counter implementation.
+     *
+     * @param counter The counter implementation
+     */
+    void assertCounting(AbstractThrottleCounter counter) throws Exception {
+        ThrottleScope scope1 = new ThrottleScope("crm", "op1");
+        int count = counter.count(scope1, 10);
+        assertThat(count, is(1));
+
+        ThrottleScope scope2 = new ThrottleScope("crm", "op2");
+        count = counter.count(scope2, 10);
+        assertThat(count, is(1));
+        count = counter.count(scope2, 10);
+        assertThat(count, is(2));
+
+        ThrottleScope scope3 = new ThrottleScope("erp", "op1");
+        count = counter.count(scope3, 10);
+        assertThat(count, is(1));
+
+        count = counter.count(scope1, 10);
+        assertThat(count, is(2));
+
+        ThrottleScope scope4 = new ThrottleScope("crm", "op4");
+        count = counter.count(scope4, 1);
+        assertThat(count, is(1));
+
+        Thread.sleep(1500);
+
+        count = counter.count(scope4, 1);
+        assertThat(count, is(1));
+
+        // test dump
+        System.out.println(counter.getCacheInfo());
+    }
+
+    /**
+     * Checks counter implementation in multi-threaded environment.
+     *
+     * @param counter The counter implementation
+     */
+    void assertMultiThreadCounting(final AbstractThrottleCounter counter) throws Exception {
+        // prepare threads
+        int threads = 5;
+        final CountDownLatch latch = new CountDownLatch(threads);
+        Runnable task = new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    // new instance for each thread
+                    ThrottleScope scope1 = new ThrottleScope("crm", "op1");
+                    ThrottleScope scope2 = new ThrottleScope("crm", "op2");
+
+                    counter.count(scope1, 10);
+                    counter.count(scope2, 10);
+                } finally {
+                    latch.countDown();
+                }
+            }
+        };
+
+        // start processing and waits for result
+        for (int i = 0; i < threads; i++) {
+            new Thread(task).start();
+        }
+
+        latch.await();
+
+        // verify counters
+        ThrottleScope scope1 = new ThrottleScope("crm", "op1");
+        ThrottleScope scope2 = new ThrottleScope("crm", "op2");
+
+        int count = counter.count(scope1, 10);
+        assertThat(count, is(threads + 1));
+
+        count = counter.count(scope2, 10);
+        assertThat(count, is(threads + 1));
+
+        // test dump
+        System.out.println(counter.getCacheInfo());
+    }
+}

--- a/core/src/test/java/org/openhubframework/openhub/core/throttling/ThrottleCounterHazelcastImplTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/throttling/ThrottleCounterHazelcastImplTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.throttling;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import org.openhubframework.openhub.spi.throttling.ThrottleScope;
+
+
+/**
+ * Test suite for {@link ThrottleCounterMemoryImpl}.
+ *
+ * @author Petr Juza
+ * @since 2.0
+ */
+public class ThrottleCounterHazelcastImplTest extends AbstractThrottleCounterTest {
+
+    private Config config;
+
+    @Before
+    public void prepareConfig() throws IOException {
+        Resource conf = new ClassPathResource("config/ohf_hazelcast.xml");
+        config = new Config();
+        config.setConfigurationFile(conf.getFile());
+    }
+
+    @After
+    public void shutdownHazelcast() {
+        // gracefully shutdowns HazelcastInstance => necessary for running another tests
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testSingleNodeCounting() throws Exception {
+        HazelcastInstance hazelcast = Hazelcast.newHazelcastInstance(config);
+        assertCounting(new ThrottleCounterHazelcastImpl(hazelcast));
+    }
+
+    @Test
+    public void testTwoNodesCounting() throws Exception {
+        HazelcastInstance hazelcast1 = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance hazelcast2 = Hazelcast.newHazelcastInstance(config);
+        ThrottleCounterHazelcastImpl counter1 = new ThrottleCounterHazelcastImpl(hazelcast1);
+        ThrottleCounterHazelcastImpl counter2 = new ThrottleCounterHazelcastImpl(hazelcast2);
+
+        assertCounting(counter1);
+
+        // see assertCounting()
+        ThrottleScope scope1 = new ThrottleScope("crm", "op1");
+        int count = counter2.count(scope1, 10);
+        assertThat(count, is(3));
+    }
+
+    @Test
+    public void testMultiThreadCountingWithSingleNode() throws Exception {
+        HazelcastInstance hazelcast = Hazelcast.newHazelcastInstance(config);
+        assertMultiThreadCounting(new ThrottleCounterHazelcastImpl(hazelcast));
+    }
+
+    @Test
+    public void testMultiThreadCountingWithTwoNodes() throws Exception {
+        HazelcastInstance hazelcast1 = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance hazelcast2 = Hazelcast.newHazelcastInstance(config);
+        ThrottleCounterHazelcastImpl counter1 = new ThrottleCounterHazelcastImpl(hazelcast1);
+        new ThrottleCounterHazelcastImpl(hazelcast2);
+
+        new ThrottleCounterHazelcastImpl(Hazelcast.newHazelcastInstance(config));
+
+        assertMultiThreadCounting(counter1);
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/OpenHubApplication.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/OpenHubApplication.java
@@ -26,6 +26,7 @@ import org.springframework.boot.context.embedded.FilterRegistrationBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.web.ErrorPageFilter;
 import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.*;
 import org.springframework.web.WebApplicationInitializer;
 
@@ -57,6 +58,7 @@ import org.openhubframework.openhub.core.config.WebServiceConfig;
  * @since 2.0
  */
 @EnableAutoConfiguration
+@EnableCaching
 @EnableConfigurationProperties
 // note: all routes with @CamelConfiguration are configured in CamelRoutesConfig
 @ComponentScan(basePackages = {

--- a/web-admin/src/main/resources/application.properties
+++ b/web-admin/src/main/resources/application.properties
@@ -251,8 +251,25 @@ camel.springboot.name=camelContext
 
 
 # ===============================
+# = HAZELCAST
+# ===============================
+# the location of the configuration file to use to initialize Hazelcast.
+# the default Hazelcast configuration
+spring.hazelcast.config=classpath:/config/ohf_hazelcast.xml
+
+
+# ===============================
 # = THROTTLING
 # ===============================
+
+# the implementation of throttling counter, there are built-in implementations such as
+#   org.openhubframework.openhub.core.throttling.ThrottleCounterMemoryImpl (default) - in-memory implementation,
+#		suitable for standalone server only
+#   org.openhubframework.openhub.core.throttling.ThrottleCounterHazelcastImpl - implementation with Hazelcast shared map,
+#		suitable for cluster
+#
+ohf.throttling.counter.impl=org.openhubframework.openhub.core.throttling.ThrottleCounterMemoryImpl
+
 
 ###############################################################################
 #  Throttling configuration


### PR DESCRIPTION
Overview of use cases where clustered cache/memory-grid could be used:

- throttling
- cache (static) external content (e.g. codebases, static file content, ...)
- cache internal OHF data
- cache configuration properties 
- use shared memory for saving runtime data, e.g. node evidence, evidence of running scheduled jobs
- cache for specific business logic implementations on projects

We decided to use Hazelcast memory grid. See [OHFJIRA-36](https://openhubframework.atlassian.net/browse/OHFJIRA-36) for more details why we selected Hazelcast.

Summary of the work:
- added throttling implementation by Hazelcast shared map
- added default Hazelcast configuration file "ohf_hazelcast.xml"
- added Hazelcast dependency
- added default cache/hazelcast configuration
- added new "cluster" Spring profile

Issue: [OHFJIRA-36](https://openhubframework.atlassian.net/browse/OHFJIRA-36)