### PR TITLE
Configure correct role name for monitoring based endpoints

### DIFF
--- a/web-admin/src/main/resources/application.properties
+++ b/web-admin/src/main/resources/application.properties
@@ -148,6 +148,10 @@ jolokia.config.debug=true
 management.add-application-context-header=false
 # Management endpoint context-path. For instance `/actuator`
 management.context-path=/mgmt
+# Security role(s) required to access the endpoints
+management.security.role=MONITORING
+# Fallback to renamed property for newer version of Spring Boot
+management.security.roles=${management.security.role}
 
 
 # ===============================


### PR DESCRIPTION
Be default all actuator endpoints (specially /health) expects `ROLE_ADMIN` role, is security is activated. OpenHub uses `ROLE_MONITORING` for monitor based endpoints.

Issue: OHFJIRA-4