### PR TITLE
H2 database is populated by default 

### DIFF
--- a/web-admin/src/main/resources/application-h2.properties
+++ b/web-admin/src/main/resources/application-h2.properties
@@ -10,7 +10,7 @@
 spring.datasource.name=OHF
 #spring.datasource.continue-on-error=false # Do not stop if an error occurs while initializing the database.
 # populate using data.sql
-spring.datasource.initialize=false
+spring.datasource.initialize=true
 # a schema (DDL) script resource reference
 #spring.datasource.schema=classpath:/db/schema-h2.sql
 # a data (DML) script resource reference


### PR DESCRIPTION
By default if H2 mode is active, initialization of datasource should be applied. To disable use:

`spring.datasource.initialize=false`

Issue: GENERAL