### PR TITLE
OHFJIRA-54: Environment and config properties overview

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <postgresql-version>9.4-1201-jdbc41</postgresql-version>
         <oracle-version>12.1.0.2</oracle-version>
 
-        <javamelody-version>1.55.0</javamelody-version>
+        <javamelody-version>1.65.0</javamelody-version>
         <metrics-version>3.1.0</metrics-version>
         <jolokia-version>1.3.2</jolokia-version>
     </properties>

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/console/ConsoleController.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/console/ConsoleController.java
@@ -16,9 +16,10 @@
 
 package org.openhubframework.openhub.admin.web.console;
 
+import org.openhubframework.openhub.config.JavaMelodyConfigurationProperties;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -29,19 +30,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
  */
 @Controller
 public class ConsoleController {
-
-    public static final String JAVAMELODY_DISABLED = "javamelody.disabled";
+    
+    @Autowired
+    private JavaMelodyConfigurationProperties javaMelodyProps;
 
     public static final String VIEW_NAME = "console";
 
     @RequestMapping("/console")
     public String showConsole(@ModelAttribute("model") ModelMap model) {
-
-        // this variable is set only if monitoring is switched on
-        final String state = System.getProperty(JAVAMELODY_DISABLED);
-
-        final Boolean monitoring = StringUtils.isEmpty(state) || Boolean.valueOf(state).equals(Boolean.TRUE);
-        model.addAttribute("javamelody", monitoring);
+        model.addAttribute("javamelody", javaMelodyProps.isEnabled());
 
         return VIEW_NAME;
     }

--- a/web-admin/src/main/java/org/openhubframework/openhub/config/JavaMelodyConfigurationProperties.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/config/JavaMelodyConfigurationProperties.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.config;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration properties for JavaMelody.
+ *
+ * @author Tomas Hanus
+ */
+@Configuration
+@ConfigurationProperties(prefix = JavaMelodyConfigurationProperties.PREFIX)
+public class JavaMelodyConfigurationProperties {
+    
+    /**
+     * Prefix of properties names.
+     */
+    public static final String PREFIX = "javamelody";
+
+    private boolean enabled = true;
+    private Map<String, String> initParameters = new HashMap<>();
+
+    /**
+     * Returns if JavaMelody should be enabled within the application.
+     *
+     * @return {@code true} if JavaMelody should be enabled, otherwise {@code false}. Default: {@code true}
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets whether JavaMelody should be enabled within the application.
+     *
+     * @param enabled {@code true} if JavaMelody should be enabled, otherwise {@code false}.
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Returns a map of initialization parameters to be passed to the JavaMelody monitoring filter.
+     *
+     * @return Initialization parameters for the JavaMelody monitoring filter.
+     */
+    public Map<String, String> getInitParameters() {
+        return initParameters;
+    }
+
+    /**
+     * Sets a map of initialization parameters to be passed to the JavaMelody monitoring filter.
+     *
+     * @param initParameters Initialization parameters for the JavaMelody monitoring filter.
+     */
+    public void setInitParameters(Map<String, String> initParameters) {
+        this.initParameters = initParameters;
+    }
+    
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("enabled", enabled)
+                .append("initParameters", initParameters)
+                .toString();
+    }
+}

--- a/web-admin/src/main/resources/application.properties
+++ b/web-admin/src/main/resources/application.properties
@@ -155,6 +155,16 @@ management.security.roles=${management.security.role}
 
 
 # ===============================
+# = JAVA MELODY
+# ===============================
+# Enable JavaMelody auto-configuration (optional, default: false)
+javamelody.enabled = false
+# Initialization parameters for JavaMelody (optional)
+#    to change the default "/monitoring" path
+javamelody.init-parameters.monitoring-path = /web/admin/monitoring/javamelody
+
+
+# ===============================
 # = SERVER CONFIGURATION
 # ===============================
 # EMBEDDED SERVER CONFIGURATION (ServerProperties)

--- a/web-admin/src/main/resources/ohf-logback.xml
+++ b/web-admin/src/main/resources/ohf-logback.xml
@@ -78,7 +78,7 @@
     <logger name="org.apache.camel.converter.jaxb.JaxbDataFormat" level="${logging.level.org.apache.camel.converter.jaxb.JaxbDataFormat:-WARN}"/>
     <logger name="org.apache.camel.processor.interceptor.Tracer" level="${logging.level.org.apache.camel.processor.interceptor.Tracer:-WARN}"/>
     <!-- Hibernate namespaces -->
-    <logger name="org.hibernate.SQL" level="INFO"/>
+    <logger name="org.hibernate.SQL" level="${logging.level.org.hibernate.SQL:-WARN}"/>
     <logger name="org.hibernate.engine.internal.StatisticalLoggingSessionEventListener" level="${logging.level.org.hibernate.engine.internal.StatisticalLoggingSessionEventListener:-ERROR}"/>
     <!-- HTTP client logging -->
     <logger name="org.apache.http" level="${logging.level.org.apache.http:-INFO}"/>


### PR DESCRIPTION
From admin GUI point of view we have to properly configure javamelody stack. Actually javamelody monitoring is disabled but it can be enabled via `javamelody.enabled = true` property. Javamelody statistics are served by default at /web/admin/monitoring/javamelody.

Endpoints to show actually used config props are exposed by Spring Boot.

[Documentation](https://openhubframework.atlassian.net/wiki/display/OHFV1/JavaMelody) is updated.

Issue: [OHFJIRA-54](https://openhubframework.atlassian.net/browse/OHFJIRA-54)