### PR TITLE
Minor improvements

### DIFF
--- a/common/src/test/java/org/openhubframework/openhub/common/converter/DataTypeConverterTest.java
+++ b/common/src/test/java/org/openhubframework/openhub/common/converter/DataTypeConverterTest.java
@@ -22,11 +22,13 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
+import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.util.regex.Pattern;
 
 import org.junit.Test;
+import org.springframework.context.i18n.LocaleContextHolder;
 
 
 /**
@@ -68,8 +70,9 @@ public class DataTypeConverterTest {
 
     @Test
     public void testFloat() throws ParseException {
-        assertConvertFrom(TypeConverterEnum.FLOAT, "13.5", 13.5f);
-        assertConvertToString(TypeConverterEnum.FLOAT, 13.5f, "13.5");
+        char separator = new DecimalFormatSymbols(LocaleContextHolder.getLocale()).getDecimalSeparator();
+        assertConvertFrom(TypeConverterEnum.FLOAT, "13" + separator + "5", 13.5f);
+        assertConvertToString(TypeConverterEnum.FLOAT, 13.5f, "13" + separator + "5");
     }
 
     @Test

--- a/web-admin/pom.xml
+++ b/web-admin/pom.xml
@@ -264,6 +264,10 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
+                <configuration>
+                    <!-- .git folder should not be mandatory -->
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
#### CHANGES
* DataTypeConverterTest updated float converter test to respect Locale separator, as it was failing on some developer environment setup
* Git-commit-id-plugin setup to ignore missing .git directory. If openhub project was checked out by using "Download as ZIP" feature of github, project build should not fail just because .git folder is missing