### PR TITLE
OHFJIRA-53: error code catalog endpoint

### DIFF
--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/ErrorsCatalog.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/ErrorsCatalog.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.api.entity;
+
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.Assert;
+
+import org.openhubframework.openhub.api.exception.ErrorCodeCatalog;
+import org.openhubframework.openhub.api.exception.ErrorExtEnum;
+
+
+/**
+ * Error catalog entity that represents catalog and values of error codes.
+ *
+ * @author Tomas Hanus
+ * @since 2.0
+ * @see #resolveName(Class)
+ * @see ErrorCodeCatalog
+ */
+public class ErrorsCatalog {
+
+    private final String name;
+    private final ErrorExtEnum[] codes;
+
+    /**
+     * Default constructor to create error catalog based upon registered error codes.
+     *
+     * @param codes as error code entries
+     * @throws IllegalArgumentException if {@code codes} does not contain some entry
+     * @see ErrorExtEnum
+     */
+    public ErrorsCatalog(ErrorExtEnum[] codes) throws IllegalArgumentException {
+        Assert.isTrue(codes.length > 0, "");
+        this.name = resolveName(codes[0].getClass());
+        this.codes = codes;
+    }
+
+    /**
+     * Constructor to create {@link ErrorsCatalog} based upon name and error code entries.
+     *
+     * @param name as name of catalog
+     * @param codes as error code entries
+     * @throws IllegalArgumentException if {@code name} is empty
+     */
+    public ErrorsCatalog(String name, ErrorExtEnum[] codes) throws IllegalArgumentException {
+        Assert.hasText(name, "Name must not be empty");
+        this.name = name;
+        this.codes = codes;
+    }
+
+    /**
+     * Constructor to create {@link ErrorsCatalog} based upon type and error code entries.
+     * 
+     * @param type of error code
+     * @param codes as entries of error codes
+     * @see #resolveName(Class) 
+     */
+    public ErrorsCatalog(Class<? extends ErrorExtEnum> type, ErrorExtEnum[] codes) {
+        this.name = resolveName(type);
+        this.codes = codes;
+    }
+
+    /**
+     * Get name of error catalog.
+     *
+     * @return catalog name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Get error codes of catalog.
+     *
+     * @return error catalog entries
+     */
+    public ErrorExtEnum[] getCodes() {
+        return codes;
+    }
+
+    /**
+     * Resolves name of catalog based upon error catalog entry.
+     *
+     * @param clazz that represents type of error catalog entry
+     * @return name of catalog
+     */
+    public String resolveName(Class clazz) throws IllegalArgumentException {
+        final ErrorCodeCatalog annotation = AnnotationUtils.findAnnotation(clazz, ErrorCodeCatalog.class);
+
+        if (annotation != null) {
+            return annotation.value();
+        } else {
+            return clazz.getClass().getSimpleName();
+        }
+    }
+}

--- a/core-api/src/main/java/org/openhubframework/openhub/api/exception/ErrorCodeCatalog.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/exception/ErrorCodeCatalog.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.api.exception;
+
+import java.lang.annotation.*;
+
+import org.springframework.core.annotation.AliasFor;
+
+
+/**
+ * Marker annotation to describe details about {@link ErrorExtEnum}.
+ *
+ * @author Tomas Hanus
+ * @since 2.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ErrorCodeCatalog {
+
+    /**
+     * The value may indicate a suggestion for a logical catalog name, for example CRM, Billing and so on.
+     *
+     * @return the suggested catalog name, if any
+     */
+    @AliasFor("name")
+    String value() default "";
+
+    /**
+     * @see #value()
+     */
+    @AliasFor("value")
+    String name() default "";
+}

--- a/core-api/src/main/java/org/openhubframework/openhub/api/exception/InternalErrorEnum.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/exception/InternalErrorEnum.java
@@ -24,6 +24,7 @@ import org.springframework.util.Assert;
  *
  * @author Petr Juza
  */
+@ErrorCodeCatalog("OHF")
 public enum InternalErrorEnum implements ErrorExtEnum {
 
     // ------------------------------------------------------------------------

--- a/core/src/main/java/org/openhubframework/openhub/core/config/CoreConfig.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/config/CoreConfig.java
@@ -16,15 +16,12 @@
 
 package org.openhubframework.openhub.core.config;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
-import org.openhubframework.openhub.api.exception.ErrorExtEnum;
+import org.openhubframework.openhub.api.entity.ErrorsCatalog;
 import org.openhubframework.openhub.api.exception.InternalErrorEnum;
 import org.openhubframework.openhub.common.Profiles;
 import org.openhubframework.openhub.core.confcheck.ConfigurationChecker;
@@ -50,12 +47,10 @@ public class CoreConfig {
     }
 
     /**
-     * Defines error codes catalogue.
+     * Defines OHF error codes catalogue.
      */
     @Bean
-    public Map<String, ErrorExtEnum[]> errorCodesCatalog() {
-        Map<String, ErrorExtEnum[]> map = new HashMap<>();
-        map.put("core", InternalErrorEnum.values());
-        return map;
+    public ErrorsCatalog coreErrorCatalog() {
+        return new ErrorsCatalog(InternalErrorEnum.values());
     }
 }

--- a/examples/src/main/java/org/openhubframework/openhub/modules/ErrorEnum.java
+++ b/examples/src/main/java/org/openhubframework/openhub/modules/ErrorEnum.java
@@ -16,6 +16,7 @@
 
 package org.openhubframework.openhub.modules;
 
+import org.openhubframework.openhub.api.exception.ErrorCodeCatalog;
 import org.openhubframework.openhub.api.exception.ErrorExtEnum;
 
 import org.springframework.util.Assert;
@@ -25,6 +26,7 @@ import org.springframework.util.Assert;
  *
  * @author Petr Juza
  */
+@ErrorCodeCatalog("CUSTOM")
 public enum ErrorEnum implements ErrorExtEnum {
 
     ;

--- a/examples/src/main/java/org/openhubframework/openhub/modules/ExampleProperties.java
+++ b/examples/src/main/java/org/openhubframework/openhub/modules/ExampleProperties.java
@@ -17,8 +17,11 @@
 package org.openhubframework.openhub.modules;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+
+import org.openhubframework.openhub.api.entity.ErrorsCatalog;
 
 
 /**
@@ -36,5 +39,15 @@ public class ExampleProperties {
      * Spring profile for module "example".
      */
     public static final String EXAMPLE_PROFILE = "example-module";
+
+    /**
+     * Register {@link ErrorEnum} as {@link ErrorsCatalog}.
+     * 
+     * @return error catalog
+     */
+    @Bean
+    public ErrorsCatalog exampleErrorCatalog() {
+        return new ErrorsCatalog(ErrorEnum.class, ErrorEnum.values());
+    }
 
 }

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/services/ErrorCatalogServiceImpl.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/services/ErrorCatalogServiceImpl.java
@@ -16,12 +16,13 @@
 
 package org.openhubframework.openhub.admin.services;
 
-import java.util.Map;
-import javax.annotation.Resource;
+import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import org.openhubframework.openhub.api.exception.ErrorExtEnum;
+import org.openhubframework.openhub.api.entity.ErrorsCatalog;
+
 
 /**
  * Implementation of {@link ErrorCatalogService}.
@@ -31,11 +32,11 @@ import org.openhubframework.openhub.api.exception.ErrorExtEnum;
 @Service
 public class ErrorCatalogServiceImpl implements ErrorCatalogService {
 
-    @Resource
-    private Map<String, ErrorExtEnum[]> errorCodesCatalog;
+    @Autowired
+    private List<ErrorsCatalog> errorCodesCatalog;
 
     @Override
-    public Map<String, ErrorExtEnum[]> getErrorCatalog() {
+    public List<ErrorsCatalog> getErrorCatalog() {
         return errorCodesCatalog;
     }
 }

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/console/ErrorCatalogController.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/console/ErrorCatalogController.java
@@ -16,6 +16,9 @@
 
 package org.openhubframework.openhub.admin.web.console;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -23,6 +26,8 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import org.openhubframework.openhub.admin.services.ErrorCatalogService;
+import org.openhubframework.openhub.api.entity.ErrorsCatalog;
+
 
 /**
  * Controller for displaying catalog of errors.
@@ -41,7 +46,10 @@ public class ErrorCatalogController {
     @RequestMapping("/" + VIEW_NAME)
     public String showErrorCatalog(@ModelAttribute("model") ModelMap model) {
 
-        model.addAttribute("errorCodesCatalog", errorCodesCatalog.getErrorCatalog());
+        final List<ErrorsCatalog> errorsCatalog = errorCodesCatalog.getErrorCatalog();
+        model.addAttribute("errorCodesCatalog", 
+                errorsCatalog.stream()
+                    .collect(Collectors.toMap(ErrorsCatalog::getName, ErrorsCatalog::getCodes)));
         return VIEW_NAME;
     }
 }

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/package-info.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/package-info.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 the original author or authors.
+ *  Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,23 +14,10 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.admin.services;
-
-import java.util.List;
-
-import org.openhubframework.openhub.api.entity.ErrorsCatalog;
-
-
 /**
- * Service for retrieving error codes catalog and display that in form of a error catalog view.
+ * Error code catalog related endpoints.
  *
  * @author Tomas Hanus
+ * @since 2.0
  */
-public interface ErrorCatalogService {
-
-    /**
-     * @return the list that holds all part of error catalog and its error codes
-     */
-    List<ErrorsCatalog> getErrorCatalog();
-
-}
+package org.openhubframework.openhub.admin.web.errorscatalog;

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rest/ErrorsCatalogController.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rest/ErrorsCatalogController.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.errorscatalog.rest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import org.openhubframework.openhub.admin.services.ErrorCatalogService;
+import org.openhubframework.openhub.admin.web.common.AbstractOhfController;
+import org.openhubframework.openhub.admin.web.errorscatalog.rpc.ErrorCodeRpc;
+import org.openhubframework.openhub.admin.web.errorscatalog.rpc.ErrorsCatalogRpc;
+import org.openhubframework.openhub.api.entity.ErrorsCatalog;
+import org.openhubframework.openhub.api.exception.ErrorExtEnum;
+
+
+/**
+ * REST controller to operate over errors catalog.
+ *
+ * @author Tomas Hanus
+ * @since 2.0
+ */
+@RestController
+@RequestMapping(value = ErrorsCatalogController.REST_URI)
+public class ErrorsCatalogController extends AbstractOhfController {
+
+    public static final String REST_URI = BASE_PATH + "/errors-catalog";
+
+    @Autowired
+    private ErrorCatalogService errorCatalogService;
+
+    /**
+     * Serves errors catalog.
+     *
+     * @return list of {@link ErrorsCatalogRpc}
+     */
+    @RequestMapping(method = RequestMethod.GET, produces = {"application/xml", "application/json"})
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public List<ErrorsCatalogRpc> errorsCatalog() {
+        final List<ErrorsCatalog> errorsCatalogList = errorCatalogService.getErrorCatalog();
+
+        final List<ErrorsCatalogRpc> result = new ArrayList<>();
+        for (ErrorsCatalog errorsCatalog : errorsCatalogList) {
+            final ErrorExtEnum[] codes = errorsCatalog.getCodes();
+            final List<ErrorCodeRpc> resultCodes = new ArrayList<>();
+            for (ErrorExtEnum code : codes) {
+                resultCodes.add(new ErrorCodeRpc(code.getErrorCode(), code.getErrDesc(), null));
+            }
+            result.add(new ErrorsCatalogRpc(errorsCatalog.getName(), resultCodes));
+        }
+        
+        return result;
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rest/package-info.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rest/package-info.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 the original author or authors.
+ *  Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,23 +14,10 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.admin.services;
-
-import java.util.List;
-
-import org.openhubframework.openhub.api.entity.ErrorsCatalog;
-
-
 /**
- * Service for retrieving error codes catalog and display that in form of a error catalog view.
- *
+ * REST endpoints for errors catalog related operations.
+ * 
  * @author Tomas Hanus
+ * @since 2.0
  */
-public interface ErrorCatalogService {
-
-    /**
-     * @return the list that holds all part of error catalog and its error codes
-     */
-    List<ErrorsCatalog> getErrorCatalog();
-
-}
+package org.openhubframework.openhub.admin.web.errorscatalog.rest;

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rpc/ErrorCodeRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rpc/ErrorCodeRpc.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.errorscatalog.rpc;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+
+/**
+ * @author Tomas Hanus
+ */
+@XmlRootElement
+public class ErrorCodeRpc {
+    
+    private final String code;
+    private final String desc;
+    private final String action;
+
+    public ErrorCodeRpc(String code, String desc, String action) {
+        this.code = code;
+        this.desc = desc;
+        this.action = action;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDesc() {
+        return desc;
+    }
+
+    public String getAction() {
+        return action;
+    }
+    
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("code", code)
+                .append("desc", desc)
+                .append("action", action)
+                .toString();
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rpc/ErrorsCatalogRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rpc/ErrorsCatalogRpc.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.errorscatalog.rpc;
+
+import java.util.Collections;
+import java.util.List;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+
+/**
+ * @author Tomas Hanus
+ */
+@XmlRootElement
+public class ErrorsCatalogRpc {
+
+    private final String name;
+    private final List<ErrorCodeRpc> codes;
+
+    public ErrorsCatalogRpc(String name, List<ErrorCodeRpc> codes) {
+        this.name = name;
+        this.codes = Collections.unmodifiableList(codes);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<ErrorCodeRpc> getCodes() {
+        return codes;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("name", name)
+                .append("codes", codes)
+                .toString();
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rpc/package-info.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rpc/package-info.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2014 the original author or authors.
+ *  Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,23 +14,10 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.admin.services;
-
-import java.util.List;
-
-import org.openhubframework.openhub.api.entity.ErrorsCatalog;
-
-
 /**
- * Service for retrieving error codes catalog and display that in form of a error catalog view.
+ * Model for REST errors catalog interface.
  *
  * @author Tomas Hanus
+ * @since 2.0
  */
-public interface ErrorCatalogService {
-
-    /**
-     * @return the list that holds all part of error catalog and its error codes
-     */
-    List<ErrorsCatalog> getErrorCatalog();
-
-}
+package org.openhubframework.openhub.admin.web.errorscatalog.rpc;

--- a/web-admin/src/test/java/org/openhubframework/openhub/admin/web/errorscatalog/rest/ErrorsCatalogControllerTest.java
+++ b/web-admin/src/test/java/org/openhubframework/openhub/admin/web/errorscatalog/rest/ErrorsCatalogControllerTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.errorscatalog.rest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import static org.openhubframework.openhub.test.rest.TestRestUtils.createGetUrl;
+import static org.openhubframework.openhub.test.rest.TestRestUtils.toUrl;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+
+import org.openhubframework.openhub.admin.AbstractAdminModuleRestTest;
+
+
+/**
+ * Test suite that verifies {@link ErrorsCatalogController} (REST API).
+ *
+ * @author Tomas Hanus
+ */
+public class ErrorsCatalogControllerTest extends AbstractAdminModuleRestTest {
+
+    private static final String ROOT_URI = ErrorsCatalogController.REST_URI;
+
+    @Test
+    public void errorsCatalog() throws Exception {
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI);
+
+        // performs GET: /api/errors-catalog
+        mockMvc.perform(get(toUrl(uriBuilder))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("[0].name", is("OHF")))
+                .andExpect(jsonPath("[0].codes[0].code", is("E100")))
+                .andExpect(jsonPath("[0].codes[0].desc", is("unspecified error")));
+    }
+
+}


### PR DESCRIPTION
OpenHub console should have page where user can see which exception code can be thrown, its description or what is recommended action. It is based upon not approved PR branch, it will be rebased.

API: http://docs.openhubframework.apiary.io/#reference/0/openhub-error-catalog-endpoint/gets-error-catalog-values

Issue: [OHFJIRA-53](https://openhubframework.atlassian.net/browse/OHFJIRA-53)