### PR TITLE
OHFJIRA-55 - DB config params endpoint improvements

### DIFF
--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/configuration/rest/DbConfigurationController.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/configuration/rest/DbConfigurationController.java
@@ -91,17 +91,20 @@ public class DbConfigurationController extends AbstractOhfController {
      * @throws ValidationIntegrationException if input object has wrong values
      * @throws NoDataFoundException entity not found for update
      */
-    @RequestMapping(method = RequestMethod.PUT, produces = {"application/xml", "application/json"})
+    // .+ is workaround how to match everything after / as code of config parameters, otherwise last .* is removed as
+    // file extension
+    @RequestMapping(value = "/{code:.+}", method = RequestMethod.PUT, produces = {"application/xml", "application/json"})
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @ResponseBody
-    public void update(@RequestBody final DbConfigurationParamRpc paramRpc) throws ValidationIntegrationException,
+    public void update(@PathVariable final String code, @RequestBody final DbConfigurationParamRpc paramRpc) throws 
+            ValidationIntegrationException,
             NoDataFoundException {
 
         Assert.notNull(paramRpc, "paramRpc can not be null");
-        Assert.notNull(paramRpc.getId(), "This method is only for update existing paramRpc.");
+        Assert.isNull(paramRpc.getCode(), "code of paramRpc must be null, object is referenced by path attribute");
 
         // get entity to update it
-        DbConfigurationParam dbParam = getParam(paramRpc.getId());
+        DbConfigurationParam dbParam = getParam(code);
         paramRpc.updateEntity(dbParam);
 
         // save entity

--- a/web-admin/src/test/java/org/openhubframework/openhub/admin/web/configuration/rest/DbConfigurationControllerTest.java
+++ b/web-admin/src/test/java/org/openhubframework/openhub/admin/web/configuration/rest/DbConfigurationControllerTest.java
@@ -96,16 +96,14 @@ public class DbConfigurationControllerTest extends AbstractAdminModuleRestTest {
 
     @Test
     public void testUpdate() throws Exception {
-        final URIBuilder uriBuilder = createGetUrl(ROOT_URI);
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI + "/" + param.getCode());
 
         JsonObject request = createJson()
-                .add("id", param.getId())
-                .add("code", param.getCode())
                 .add("currentValue", "222")
                 .add("defaultValue", "10")
                 .build();
 
-        // performs PUT: /api/config-params
+        // performs PUT: /api/config-params/ohf.async.concurrentConsumers
         mockMvc.perform(put(toUrl(uriBuilder))
                 .content(request.toString())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -124,11 +122,9 @@ public class DbConfigurationControllerTest extends AbstractAdminModuleRestTest {
 
     @Test
     public void testUpdate_wrongValueType() throws Exception {
-        final URIBuilder uriBuilder = createGetUrl(ROOT_URI);
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI + "/" + param.getCode());
 
         JsonObject request = createJson()
-                .add("id", param.getId())
-                .add("code", param.getCode())
                 .add("currentValue", "abc")
                 .build();
 


### PR DESCRIPTION
Best practise is to avoid duplication of PK (id, code) between URL PA…TH and payload.

There should be only one place where unique identifier is, for example to check authorization of requester to perform this action. This change is documented (changed) in Apiary.

Issue: [OHFJIRA-55](https://openhubframework.atlassian.net/browse/OHFJIRA-55)