### PR TITLE
OHFJIRA-56: loggers endpoint

### DIFF
--- a/web-admin/src/main/resources/application.properties
+++ b/web-admin/src/main/resources/application.properties
@@ -141,6 +141,11 @@ endpoints.jolokia.path=/jolokia
 # Enable security on the endpoint.
 endpoints.jolokia.sensitive=true
 
+# Enable Loggers endpoint.
+endpoints.loggers.enabled=true
+# Endpoint URL path.
+endpoints.loggers.path=/loggers
+
 # JOLOKIA (JolokiaProperties)
 jolokia.config.debug=true
 #jolokia.config.*= # See Jolokia manual


### PR DESCRIPTION
[Since Spring Boot 1.5 version](http://docs.spring.io/spring-boot/docs/1.5.x/reference/htmlsingle/#production-ready-loggers) there is simple solution how to view either the entire list or an individual logger’s configuration which is made up of both the explicitly configured logging level as well as the effective logging level given to it by the logging framework.

We can implement user friendly approach how to configure loggers in runtime and via GUI admin console. API is designed in Apiary - http://docs.openhubframework.apiary.io/#reference/0/openhub-loggers-management.

![image](https://cloud.githubusercontent.com/assets/5721496/24879816/59746998-1e38-11e7-8529-4420b75267d0.png)

See Sprint Boot support:
- https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-1.5-Release-Notes#loggers-endpoint

Issue: [OHFJIRA-56](https://openhubframework.atlassian.net/browse/OHFJIRA-56)