### PR TITLE
REST base - validations

### DIFF
--- a/core-api/src/main/java/org/openhubframework/openhub/api/common/Constraints.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/common/Constraints.java
@@ -18,14 +18,13 @@ package org.openhubframework.openhub.api.common;
 
 
 import org.openhubframework.openhub.api.exception.ErrorExtEnum;
-import org.openhubframework.openhub.api.exception.IllegalDataException;
-import org.openhubframework.openhub.api.exception.InternalErrorEnum;
-import org.openhubframework.openhub.api.exception.ValidationIntegrationException;
+import org.openhubframework.openhub.api.exception.validation.IllegalDataException;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
 
 
 /**
  * Assertion utility class that assists in validating arguments by throwing specific
- * {@link ValidationIntegrationException} exceptions.
+ * {@link ValidationException} exceptions.
  *
  * <p>Useful for identifying data integration errors early and clearly at runtime.
  *
@@ -50,7 +49,7 @@ public final class Constraints {
     public static void hasText(String text, String message) throws IllegalDataException {
         notNull(text, message);
         if (!org.springframework.util.StringUtils.hasText(text)) {
-            throw new IllegalDataException(InternalErrorEnum.E109, message);
+            throw new IllegalDataException(message);
         }
     }
 
@@ -74,19 +73,21 @@ public final class Constraints {
     /**
      * Assert that an object is not {@code null}.
      * <pre class="code">Assert.notNull(clazz, "The class must not be null");</pre>
+     *
      * @param object the object to check
      * @param message the exception message to use if the assertion fails
      * @throws IllegalArgumentException if the object is {@code null}
      */
     public static void notNull(Object object, String message) {
         if (object == null) {
-            throw new IllegalDataException(InternalErrorEnum.E109, message);
+            throw new IllegalDataException(message);
         }
     }
 
     /**
      * Assert that an object is not {@code null}.
      * <pre class="code">Assert.notNull(clazz, "The class must not be null");</pre>
+     *
      * @param object the object to check
      * @param message the exception message to use if the assertion fails
      * @param errorCode the internal error code
@@ -101,19 +102,21 @@ public final class Constraints {
     /**
      * Assert that an object <strong>is</strong> {@code null}.
      * <pre class="code">Assert.isNull(clazz, "The class must be null");</pre>
+     *
      * @param object the object to check
      * @param message the exception message to use if the assertion fails
      * @throws IllegalArgumentException if the object is not {@code null}
      */
     public static void isNull(Object object, String message) {
         if (object != null) {
-            throw new IllegalDataException(InternalErrorEnum.E109, message);
+            throw new IllegalDataException(message);
         }
     }
 
     /**
      * Assert that an object <strong>is</strong> {@code null}.
      * <pre class="code">Assert.isNull(clazz, "The class must be null");</pre>
+     *
      * @param object the object to check
      * @param message the exception message to use if the assertion fails
      * @param errorCode the internal error code
@@ -128,6 +131,7 @@ public final class Constraints {
     /**
      * Assert a boolean expression, throwing {@code IllegalArgumentException}
      * if the test result is {@code false}.
+     *
      * @param expression a boolean expression
      * @param message the exception message to use if the assertion fails
      * @throws IllegalArgumentException if expression is {@code false}
@@ -135,13 +139,14 @@ public final class Constraints {
     public static void isTrue(Boolean expression, String message) {
         notNull(expression, message);
         if (expression.booleanValue() != Boolean.TRUE) {
-            throw new IllegalDataException(InternalErrorEnum.E109, message);
+            throw new IllegalDataException(message);
         }
     }
 
     /**
      * Assert a boolean expression, throwing {@code IllegalArgumentException}
      * if the test result is {@code false}.
+     *
      * @param expression a boolean expression
      * @param message the exception message to use if the assertion fails
      * @param errorCode the internal error code
@@ -153,6 +158,22 @@ public final class Constraints {
             throw new IllegalDataException(errorCode, message);
         }
     }
+
+    /**
+   	 * Assert a boolean expression, throwing {@code IllegalStateException}
+   	 * if the test result is {@code false}. Call isTrue if you wish to
+   	 * throw IllegalArgumentException on an assertion failure.
+   	 * <pre class="code">Assert.state(id == null, "The id property must not already be initialized");</pre>
+     *
+   	 * @param expression a boolean expression
+   	 * @param message the exception message to use if the assertion fails
+   	 * @throws IllegalStateException if expression is {@code false}
+   	 */
+   	public static void state(boolean expression, String message) {
+   		if (!expression) {
+   			throw new IllegalDataException(message);
+   		}
+   	}
 
     private Constraints() {
     }

--- a/core-api/src/main/java/org/openhubframework/openhub/api/common/ExchangeHelper.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/common/ExchangeHelper.java
@@ -20,12 +20,12 @@ import static org.openhubframework.openhub.api.common.ExchangeConstants.TRACE_HE
 
 import javax.annotation.Nullable;
 
-import org.openhubframework.openhub.api.asynch.model.TraceHeader;
-import org.openhubframework.openhub.api.exception.IllegalDataException;
-
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.springframework.util.Assert;
+
+import org.openhubframework.openhub.api.asynch.model.TraceHeader;
+import org.openhubframework.openhub.api.exception.validation.IllegalDataException;
 
 /**
  * Some helper methods for working with {@link Exchange} objects.

--- a/core-api/src/main/java/org/openhubframework/openhub/api/configuration/ConfigurationItem.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/configuration/ConfigurationItem.java
@@ -16,7 +16,7 @@
 
 package org.openhubframework.openhub.api.configuration;
 
-import org.openhubframework.openhub.api.exception.ConfigurationException;
+import org.openhubframework.openhub.api.exception.validation.ConfigurationException;
 
 
 /**

--- a/core-api/src/main/java/org/openhubframework/openhub/api/configuration/DbConfigurationParam.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/configuration/DbConfigurationParam.java
@@ -27,7 +27,7 @@ import org.springframework.core.convert.ConversionService;
 
 import org.openhubframework.openhub.api.common.Constraints;
 import org.openhubframework.openhub.api.entity.SuperEntity;
-import org.openhubframework.openhub.api.exception.ConfigurationException;
+import org.openhubframework.openhub.api.exception.validation.ConfigurationException;
 import org.openhubframework.openhub.common.Tools;
 
 
@@ -72,10 +72,11 @@ public class DbConfigurationParam extends SuperEntity<String> {
     @Column(name = "validation", length = 100)
     private String validationRegEx;
 
-
-    /** Default public constructor. */
-    public DbConfigurationParam() {
-        super(null);
+    /**
+     * Default no-args constructor used only by JPA.
+     */
+    private DbConfigurationParam() {
+        // super SuperEntity is used by default
     }
 
     /**

--- a/core-api/src/main/java/org/openhubframework/openhub/api/configuration/DbConfigurationParamService.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/configuration/DbConfigurationParamService.java
@@ -19,7 +19,7 @@ package org.openhubframework.openhub.api.configuration;
 import java.util.List;
 import java.util.Optional;
 
-import org.openhubframework.openhub.api.exception.ConfigurationException;
+import org.openhubframework.openhub.api.exception.validation.ConfigurationException;
 
 
 /**

--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/ExternalCall.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/ExternalCall.java
@@ -80,11 +80,6 @@ public class ExternalCall extends SuperEntity<Long> {
     @Column(name = "failed_count", nullable = false)
     private int failedCount = 0;
 
-    /** Default public constructor. */
-    public ExternalCall() {
-        super(null);
-    }
-
     /**
      * Creates new {@link ExternalCallStateEnum#FAILED failed} confirmation call.
      *

--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/Request.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/Request.java
@@ -78,11 +78,6 @@ public class Request extends SuperEntity<Long> {
     @Column(name = "req_timestamp", nullable = false)
     private Instant reqTimestamp;
 
-    /** Default public constructor. */
-    public Request() {
-        super(null);
-    }
-
     /**
      * Creates a new request.
      *

--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/Response.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/Response.java
@@ -64,11 +64,6 @@ public class Response extends SuperEntity<Long> {
     @Column(name = "failed", nullable = false)
     private boolean failed;
 
-    /** Default public constructor. */
-    public Response() {
-        super(null);
-    }
-
     /**
      * Creates a new response.
      *

--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/SuperEntity.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/SuperEntity.java
@@ -50,6 +50,13 @@ public abstract class SuperEntity<ID extends Serializable> implements Serializab
         this.id = id;
     }
 
+    /**
+     * Creates new entity with {@code null} identifier.
+     */
+    protected SuperEntity() {
+        this(null);
+    }
+
     @Override
     public void setId(@Nullable ID id) {
         this.id = id;

--- a/core-api/src/main/java/org/openhubframework/openhub/api/exception/validation/ConfigurationException.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/exception/validation/ConfigurationException.java
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.api.exception;
+package org.openhubframework.openhub.api.exception.validation;
+
+import org.openhubframework.openhub.api.exception.InternalErrorEnum;
+
 
 /**
  * Configuration exception that reflects error state of configuration item.
@@ -22,7 +25,7 @@ package org.openhubframework.openhub.api.exception;
  * @author Tomas Hanus
  * @since 2.0
  */
-public class ConfigurationException extends ValidationIntegrationException {
+public class ConfigurationException extends ValidationException {
 
     private static final long serialVersionUID = 1L;
 

--- a/core-api/src/main/java/org/openhubframework/openhub/api/exception/validation/IllegalDataException.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/exception/validation/IllegalDataException.java
@@ -14,39 +14,40 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.api.exception;
+package org.openhubframework.openhub.api.exception.validation;
 
 import javax.annotation.Nullable;
 
-import org.openhubframework.openhub.api.entity.MsgStateEnum;
+import org.openhubframework.openhub.api.exception.ErrorExtEnum;
+import org.openhubframework.openhub.api.exception.InternalErrorEnum;
 
 
 /**
- * Exception indicates error during validation.
- * <p>
- * If there is validation error than there is no next try, message gets to {@link MsgStateEnum#FAILED FAILED state}.
+ * Exception indicates non-valid, illegal data.
  *
  * @author Petr Juza
  */
-public class ValidationIntegrationException extends IntegrationException {
+public class IllegalDataException extends ValidationException {
 
     /**
-     * Creates validation exception with the message and {@link InternalErrorEnum#E102} error code.
+     * Creates exception with the message and {@link InternalErrorEnum#E109} error code.
      *
      * @param msg the message
      */
-    public ValidationIntegrationException(String msg) {
-        super(InternalErrorEnum.E102, msg);
+    public IllegalDataException(String msg) {
+        this(InternalErrorEnum.E109, msg);
     }
 
     /**
-     * Creates validation exception with the specified error code.
+     * Creates exception with the message, {@link InternalErrorEnum#E109} error code and specified cause.
      *
-     * @param error the error code
+     * @param msg   the message
+     * @param cause the throwable that caused this exception
      */
-    public ValidationIntegrationException(ErrorExtEnum error) {
-        super(error);
+    public IllegalDataException(String msg, Throwable cause) {
+        this(InternalErrorEnum.E109, msg, cause);
     }
+
 
     /**
      * Creates validation exception with the specified error code and message.
@@ -54,7 +55,7 @@ public class ValidationIntegrationException extends IntegrationException {
      * @param error the error code
      * @param msg   the message
      */
-    public ValidationIntegrationException(ErrorExtEnum error, String msg) {
+    public IllegalDataException(ErrorExtEnum error, String msg) {
         super(error, msg);
     }
 
@@ -65,7 +66,7 @@ public class ValidationIntegrationException extends IntegrationException {
      * @param msg   the message
      * @param cause the throwable that caused this exception
      */
-    public ValidationIntegrationException(ErrorExtEnum error, @Nullable String msg, @Nullable Throwable cause) {
+    public IllegalDataException(ErrorExtEnum error, @Nullable String msg, @Nullable Throwable cause) {
         super(error, msg, cause);
     }
 }

--- a/core-api/src/main/java/org/openhubframework/openhub/api/exception/validation/InputValidationException.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/exception/validation/InputValidationException.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.api.exception.validation;
+
+import javax.annotation.Nullable;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.util.Assert;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import org.openhubframework.openhub.api.exception.ErrorExtEnum;
+import org.openhubframework.openhub.api.exception.InternalErrorEnum;
+import org.openhubframework.openhub.common.Tools;
+
+
+/**
+ * Validation exception indicates error(s) in input data.
+ * Exception encapsulates {@link BindingResult input errors}.
+ *
+ * @author Petr Juza
+ * @since 2.0
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class InputValidationException extends ValidationException {
+
+    private BindingResult bindingResult;
+
+    /**
+     * Creates exception with binding errors.
+     *
+     * @param bindingResult Binding errors
+     */
+    public InputValidationException(BindingResult bindingResult) {
+        this(bindingResult, InternalErrorEnum.E109);
+    }
+
+    /**
+     * Creates exception with binding errors and specific error code.
+     *
+     * @param bindingResult Binding errors
+     * @param error The error code
+     */
+    public InputValidationException(BindingResult bindingResult, @Nullable ErrorExtEnum error) {
+        super(error, null, null);
+
+        Assert.notNull(bindingResult, "bindingResult must not be null");
+
+        this.bindingResult = bindingResult;
+    }
+
+    public BindingResult getBindingResult() {
+        return bindingResult;
+    }
+
+    @Override
+    public String getMessage() {
+        return Tools.fm("Input validation error in object '{}'", bindingResult.getObjectName());
+    }
+}

--- a/core-api/src/main/java/org/openhubframework/openhub/api/exception/validation/ValidationException.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/exception/validation/ValidationException.java
@@ -14,37 +14,42 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.api.exception;
+package org.openhubframework.openhub.api.exception.validation;
 
 import javax.annotation.Nullable;
 
+import org.openhubframework.openhub.api.entity.MsgStateEnum;
+import org.openhubframework.openhub.api.exception.ErrorExtEnum;
+import org.openhubframework.openhub.api.exception.IntegrationException;
+import org.openhubframework.openhub.api.exception.InternalErrorEnum;
+
 
 /**
- * Exception indicates non-valid, illegal data.
+ * Exception indicates error during validation.
+ * <p>
+ * If there is validation error than there is no next try, message gets to {@link MsgStateEnum#FAILED FAILED state}.
  *
  * @author Petr Juza
  */
-public class IllegalDataException extends ValidationIntegrationException {
+public class ValidationException extends IntegrationException {
 
     /**
-     * Creates exception with the message and {@link InternalErrorEnum#E109} error code.
+     * Creates validation exception with the message and {@link InternalErrorEnum#E102} error code.
      *
      * @param msg the message
      */
-    public IllegalDataException(String msg) {
-        this(InternalErrorEnum.E109, msg);
+    public ValidationException(String msg) {
+        super(InternalErrorEnum.E102, msg);
     }
 
     /**
-     * Creates exception with the message, {@link InternalErrorEnum#E109} error code and specified cause.
+     * Creates validation exception with the specified error code.
      *
-     * @param msg   the message
-     * @param cause the throwable that caused this exception
+     * @param error the error code
      */
-    public IllegalDataException(String msg, Throwable cause) {
-        this(InternalErrorEnum.E109, msg, cause);
+    public ValidationException(ErrorExtEnum error) {
+        super(error);
     }
-
 
     /**
      * Creates validation exception with the specified error code and message.
@@ -52,7 +57,7 @@ public class IllegalDataException extends ValidationIntegrationException {
      * @param error the error code
      * @param msg   the message
      */
-    public IllegalDataException(ErrorExtEnum error, String msg) {
+    public ValidationException(ErrorExtEnum error, String msg) {
         super(error, msg);
     }
 
@@ -63,7 +68,7 @@ public class IllegalDataException extends ValidationIntegrationException {
      * @param msg   the message
      * @param cause the throwable that caused this exception
      */
-    public IllegalDataException(ErrorExtEnum error, @Nullable String msg, @Nullable Throwable cause) {
+    public ValidationException(ErrorExtEnum error, @Nullable String msg, @Nullable Throwable cause) {
         super(error, msg, cause);
     }
 }

--- a/core-api/src/main/java/org/openhubframework/openhub/api/exception/validation/package-info.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/exception/validation/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Validation exceptions.
+ */
+package org.openhubframework.openhub.api.exception.validation;

--- a/core-api/src/main/java/org/openhubframework/openhub/api/route/AbstractBasicRoute.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/route/AbstractBasicRoute.java
@@ -24,7 +24,6 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Handler;
 import org.apache.camel.Header;
 import org.apache.camel.LoggingLevel;
-import org.apache.camel.ValidationException;
 import org.apache.camel.processor.DefaultExchangeFormatter;
 import org.apache.camel.spi.EventNotifier;
 import org.apache.camel.spring.SpringRouteBuilder;
@@ -33,18 +32,17 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.openhubframework.openhub.api.asynch.AsynchConstants;
-import org.openhubframework.openhub.api.entity.ExternalSystemExtEnum;
-import org.openhubframework.openhub.api.entity.ServiceExtEnum;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Assert;
 
+import org.openhubframework.openhub.api.asynch.AsynchConstants;
+import org.openhubframework.openhub.api.entity.ExternalSystemExtEnum;
+import org.openhubframework.openhub.api.entity.ServiceExtEnum;
 import org.openhubframework.openhub.api.exception.BusinessException;
 import org.openhubframework.openhub.api.exception.LockFailureException;
 import org.openhubframework.openhub.api.exception.MultipleDataFoundException;
 import org.openhubframework.openhub.api.exception.NoDataFoundException;
-import org.openhubframework.openhub.api.exception.ValidationIntegrationException;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
 
 
 /**
@@ -160,8 +158,8 @@ public abstract class AbstractBasicRoute extends SpringRouteBuilder {
 
         String nextUri;
 
-        if (ExceptionUtils.indexOfThrowable(ex, ValidationException.class) >= 0
-                || ExceptionUtils.indexOfThrowable(ex, ValidationIntegrationException.class) >= 0) {
+        if (ExceptionUtils.indexOfThrowable(ex, org.apache.camel.ValidationException.class) >= 0
+                || ExceptionUtils.indexOfThrowable(ex, ValidationException.class) >= 0) {
             LOG.warn("Validation error, no further processing - " + ex.getMessage());
             nextUri = AsynchConstants.URI_ERROR_FATAL;
 

--- a/core-api/src/main/java/org/openhubframework/openhub/api/route/XPathValidator.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/route/XPathValidator.java
@@ -29,12 +29,12 @@ import org.springframework.util.Assert;
 import org.w3c.dom.NodeList;
 
 import org.openhubframework.openhub.api.exception.InternalErrorEnum;
-import org.openhubframework.openhub.api.exception.ValidationIntegrationException;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
 
 
 /**
  * XPath validator that checks existence of mandatory element values (only those which have text values, not other sub-elements).
- * If there is no specified element (also with any value) then {@link ValidationIntegrationException} is thrown.
+ * If there is no specified element (also with any value) then {@link ValidationException} is thrown.
  * <p>
  * Input XML:
  * <pre>
@@ -131,6 +131,6 @@ public class XPathValidator implements Processor {
      * @param msg the exception message
      */
     protected void throwException(String msg) {
-        throw new ValidationIntegrationException(InternalErrorEnum.E110, msg);
+        throw new ValidationException(InternalErrorEnum.E110, msg);
     }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/TraceHeaderProcessor.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/TraceHeaderProcessor.java
@@ -35,7 +35,7 @@ import org.openhubframework.openhub.api.asynch.model.TraceHeader;
 import org.openhubframework.openhub.api.asynch.model.TraceIdentifier;
 import org.openhubframework.openhub.api.common.ExchangeConstants;
 import org.openhubframework.openhub.api.exception.InternalErrorEnum;
-import org.openhubframework.openhub.api.exception.ValidationIntegrationException;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
 import org.openhubframework.openhub.core.common.validator.TraceIdentifierValidator;
 
 
@@ -112,7 +112,7 @@ public class TraceHeaderProcessor implements Processor {
         }
 
         if (isMandatoryHeader()) {
-            throw new ValidationIntegrationException(InternalErrorEnum.E104);
+            throw new ValidationException(InternalErrorEnum.E104);
         }
     }
 
@@ -128,24 +128,24 @@ public class TraceHeaderProcessor implements Processor {
         TraceHeader traceHeader = unmarshaller.unmarshal(traceHeaderElmSource, TraceHeader.class).getValue();
         if (traceHeader == null) {
             if (isMandatoryHeader()) {
-                throw new ValidationIntegrationException(InternalErrorEnum.E105, "there is no trace header");
+                throw new ValidationException(InternalErrorEnum.E105, "there is no trace header");
             }
         } else {
             // validate header content
             TraceIdentifier traceId = traceHeader.getTraceIdentifier();
             if (traceId == null) {
                 if (isMandatoryHeader()) {
-                    throw new ValidationIntegrationException(InternalErrorEnum.E105, "there is no trace identifier");
+                    throw new ValidationException(InternalErrorEnum.E105, "there is no trace identifier");
                 }
             } else {
                 if (traceId.getApplicationID() == null) {
-                    throw new ValidationIntegrationException(InternalErrorEnum.E105, "there is no application ID");
+                    throw new ValidationException(InternalErrorEnum.E105, "there is no application ID");
 
                 } else if (traceId.getCorrelationID() == null) {
-                    throw new ValidationIntegrationException(InternalErrorEnum.E105, "there is no correlation ID");
+                    throw new ValidationException(InternalErrorEnum.E105, "there is no correlation ID");
 
                 } else if (traceId.getTimestamp() == null) {
-                    throw new ValidationIntegrationException(InternalErrorEnum.E105, "there is no timestamp ID");
+                    throw new ValidationException(InternalErrorEnum.E105, "there is no timestamp ID");
                 }
 
                 validateTraceIdentifier(traceId);
@@ -172,7 +172,7 @@ public class TraceHeaderProcessor implements Processor {
      * Checks that {@link TraceIdentifier} contains values which are valid.
      *
      * @param traceId the {@link TraceIdentifier}
-     * @throws ValidationIntegrationException
+     * @throws ValidationException
      */
     private void validateTraceIdentifier(TraceIdentifier traceId) {
         Assert.notNull(traceId, "the traceId must not be null");
@@ -191,7 +191,7 @@ public class TraceHeaderProcessor implements Processor {
         }
 
         // trace identifier values was not found in any list of possible values
-        throw new ValidationIntegrationException(InternalErrorEnum.E120,
+        throw new ValidationException(InternalErrorEnum.E120,
                 "the trace identifier '" + ToStringBuilder.reflectionToString(traceId,
                         ToStringStyle.SHORT_PREFIX_STYLE) + "' is not allowed");
     }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/ws/HeaderAndPayloadValidatingInterceptor.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/ws/HeaderAndPayloadValidatingInterceptor.java
@@ -17,33 +17,21 @@
 package org.openhubframework.openhub.core.common.ws;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
+import java.util.*;
 import javax.xml.namespace.QName;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMSource;
 
-import org.openhubframework.openhub.api.exception.InternalErrorEnum;
-import org.openhubframework.openhub.api.exception.ValidationIntegrationException;
-
 import org.springframework.util.ObjectUtils;
 import org.springframework.ws.context.MessageContext;
-import org.springframework.ws.soap.SoapBody;
-import org.springframework.ws.soap.SoapFault;
-import org.springframework.ws.soap.SoapFaultDetail;
-import org.springframework.ws.soap.SoapFaultDetailElement;
-import org.springframework.ws.soap.SoapHeader;
-import org.springframework.ws.soap.SoapHeaderElement;
-import org.springframework.ws.soap.SoapMessage;
+import org.springframework.ws.soap.*;
 import org.springframework.ws.soap.saaj.SaajSoapMessage;
 import org.springframework.ws.soap.server.endpoint.interceptor.PayloadValidatingInterceptor;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
+
+import org.openhubframework.openhub.api.exception.InternalErrorEnum;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
 
 
 /**
@@ -79,7 +67,7 @@ public class HeaderAndPayloadValidatingInterceptor extends PayloadValidatingInte
             SaajSoapMessage soapMessage = (SaajSoapMessage) messageContext.getRequest();
             SoapHeader soapHeader = soapMessage.getSoapHeader();
 
-            ValidationIntegrationException[] errors = validateHeader(soapHeader);
+            ValidationException[] errors = validateHeader(soapHeader);
             if (!ObjectUtils.isEmpty(errors)) {
                 return handleHeaderValidationErrors(messageContext, errors);
             } else if (logger.isDebugEnabled()) {
@@ -108,8 +96,8 @@ public class HeaderAndPayloadValidatingInterceptor extends PayloadValidatingInte
      * @param soapHeader the SOAP header
      * @return array of possible validation errors
      */
-    private ValidationIntegrationException[] validateHeader(SoapHeader soapHeader) {
-        List<ValidationIntegrationException> errors = new ArrayList<ValidationIntegrationException>();
+    private ValidationException[] validateHeader(SoapHeader soapHeader) {
+        List<ValidationException> errors = new ArrayList<ValidationException>();
 
         boolean headerFound = false;
         if (soapHeader != null) {
@@ -124,10 +112,10 @@ public class HeaderAndPayloadValidatingInterceptor extends PayloadValidatingInte
         }
 
         if (!headerFound) {
-            errors.add(new ValidationIntegrationException("there is no header element: " + TRACE_HEADER_ELM));
+            errors.add(new ValidationException("there is no header element: " + TRACE_HEADER_ELM));
         }
 
-        return errors.toArray(new ValidationIntegrationException[errors.size()]);
+        return errors.toArray(new ValidationException[errors.size()]);
     }
 
     /**
@@ -139,10 +127,10 @@ public class HeaderAndPayloadValidatingInterceptor extends PayloadValidatingInte
      * @return <code>true</code> to continue processing the request, <code>false</code> (the default) otherwise
      * @throws TransformerException if error occurs during the transformation process
      */
-    protected boolean handleHeaderValidationErrors(MessageContext messageContext, ValidationIntegrationException[] errors)
+    protected boolean handleHeaderValidationErrors(MessageContext messageContext, ValidationException[] errors)
             throws TransformerException {
 
-        for (ValidationIntegrationException error : errors) {
+        for (ValidationException error : errors) {
             logger.warn("XML validation error on request: " + error.getMessage());
         }
 
@@ -153,7 +141,7 @@ public class HeaderAndPayloadValidatingInterceptor extends PayloadValidatingInte
 
             if (getAddValidationErrorDetail()) {
                 SoapFaultDetail detail = fault.addFaultDetail();
-                for (ValidationIntegrationException error : errors) {
+                for (ValidationException error : errors) {
                     SoapFaultDetailElement detailElement = detail.addFaultDetailElement(getDetailElementName());
                     detailElement.addText(error.getMessage());
                 }

--- a/core/src/main/java/org/openhubframework/openhub/core/confcheck/ConfCheck.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/confcheck/ConfCheck.java
@@ -16,7 +16,7 @@
 
 package org.openhubframework.openhub.core.confcheck;
 
-import org.openhubframework.openhub.api.exception.ConfigurationException;
+import org.openhubframework.openhub.api.exception.validation.ConfigurationException;
 
 
 /**

--- a/core/src/main/java/org/openhubframework/openhub/core/confcheck/ConfigurationChecker.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/confcheck/ConfigurationChecker.java
@@ -45,7 +45,7 @@ import org.springframework.web.context.WebApplicationContext;
 import org.openhubframework.openhub.api.configuration.ConfigurableValue;
 import org.openhubframework.openhub.api.configuration.ConfigurationItem;
 import org.openhubframework.openhub.api.configuration.CoreProps;
-import org.openhubframework.openhub.api.exception.ConfigurationException;
+import org.openhubframework.openhub.api.exception.validation.ConfigurationException;
 
 
 /**

--- a/core/src/main/java/org/openhubframework/openhub/core/configuration/ConfigurationItemImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/configuration/ConfigurationItemImpl.java
@@ -17,7 +17,7 @@
 package org.openhubframework.openhub.core.configuration;
 
 import org.openhubframework.openhub.api.configuration.ConfigurationItem;
-import org.openhubframework.openhub.api.exception.ConfigurationException;
+import org.openhubframework.openhub.api.exception.validation.ConfigurationException;
 
 
 /**

--- a/core/src/main/java/org/openhubframework/openhub/core/configuration/DbConfigurationParamServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/configuration/DbConfigurationParamServiceImpl.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.openhubframework.openhub.api.common.Constraints;
 import org.openhubframework.openhub.api.configuration.DbConfigurationParam;
 import org.openhubframework.openhub.api.configuration.DbConfigurationParamService;
-import org.openhubframework.openhub.api.exception.ConfigurationException;
+import org.openhubframework.openhub.api.exception.validation.ConfigurationException;
 import org.openhubframework.openhub.common.Tools;
 
 

--- a/core/src/main/java/org/openhubframework/openhub/core/node/NodeServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/node/NodeServiceImpl.java
@@ -19,7 +19,7 @@ import org.openhubframework.openhub.api.configuration.ConfigurationItem;
 import org.openhubframework.openhub.api.configuration.CoreProps;
 import org.openhubframework.openhub.api.entity.MutableNode;
 import org.openhubframework.openhub.api.entity.Node;
-import org.openhubframework.openhub.api.exception.ConfigurationException;
+import org.openhubframework.openhub.api.exception.validation.ConfigurationException;
 import org.openhubframework.openhub.core.common.dao.NodeDao;
 import org.openhubframework.openhub.core.confcheck.ConfCheck;
 import org.openhubframework.openhub.spi.node.ChangeNodeCallback;

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRouteConfirmTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRouteConfirmTest.java
@@ -45,7 +45,7 @@ import org.openhubframework.openhub.api.entity.Message;
 import org.openhubframework.openhub.api.entity.MsgStateEnum;
 import org.openhubframework.openhub.api.exception.IntegrationException;
 import org.openhubframework.openhub.api.exception.InternalErrorEnum;
-import org.openhubframework.openhub.api.exception.ValidationIntegrationException;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
 import org.openhubframework.openhub.api.route.AbstractBasicRoute;
 import org.openhubframework.openhub.common.time.Seconds;
 import org.openhubframework.openhub.core.AbstractCoreDbTest;
@@ -155,7 +155,7 @@ public class AsynchMessageRouteConfirmTest extends AbstractCoreDbTest {
     @Test
     public void testConfirmationStatusFailed() throws Exception {
         // simulate fatal failure:
-        mock.whenAnyExchangeReceived(TestCamelUtils.throwException(new ValidationIntegrationException(InternalErrorEnum.E102)));
+        mock.whenAnyExchangeReceived(TestCamelUtils.throwException(new ValidationException(InternalErrorEnum.E102)));
 
         // save message into DB
         em.persist(msg);

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRouteTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRouteTest.java
@@ -50,15 +50,14 @@ import org.openhubframework.openhub.api.event.FailedMsgAsynchEvent;
 import org.openhubframework.openhub.api.event.PartlyFailedMsgAsynchEvent;
 import org.openhubframework.openhub.api.exception.IntegrationException;
 import org.openhubframework.openhub.api.exception.InternalErrorEnum;
-import org.openhubframework.openhub.api.exception.ValidationIntegrationException;
 import org.openhubframework.openhub.api.route.AbstractBasicRoute;
 import org.openhubframework.openhub.core.AbstractCoreDbTest;
 import org.openhubframework.openhub.core.common.asynch.msg.MessageSplitterImpl;
 import org.openhubframework.openhub.core.configuration.FixedConfigurationItem;
 import org.openhubframework.openhub.spi.msg.MessageService;
-import org.openhubframework.openhub.test.TestCamelUtils;
 import org.openhubframework.openhub.spi.node.ChangeNodeCallback;
 import org.openhubframework.openhub.spi.node.NodeService;
+import org.openhubframework.openhub.test.TestCamelUtils;
 import org.openhubframework.openhub.test.data.EntityTypeTestEnum;
 import org.openhubframework.openhub.test.data.ErrorTestEnum;
 import org.openhubframework.openhub.test.data.ExternalSystemTestEnum;
@@ -359,7 +358,7 @@ public class AsynchMessageRouteTest extends AbstractCoreDbTest {
             @Override
             protected void doConfigure() throws Exception {
                 from(subRouteUri)
-                    .process(TestCamelUtils.throwException(new ValidationIntegrationException(
+                    .process(TestCamelUtils.throwException(new org.openhubframework.openhub.api.exception.validation.ValidationException(
                             InternalErrorEnum.E102)));
             }
         };

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/TraceHeaderProcessorTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/TraceHeaderProcessorTest.java
@@ -26,13 +26,6 @@ import static org.junit.Assert.fail;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.openhubframework.openhub.api.asynch.model.TraceHeader;
-import org.openhubframework.openhub.api.asynch.model.TraceIdentifier;
-import org.openhubframework.openhub.api.exception.InternalErrorEnum;
-import org.openhubframework.openhub.api.exception.ValidationIntegrationException;
-import org.openhubframework.openhub.core.AbstractCoreTest;
-import org.openhubframework.openhub.core.common.validator.TraceIdentifierValidator;
-
 import org.apache.camel.EndpointInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.Produce;
@@ -40,6 +33,13 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.junit.Test;
+
+import org.openhubframework.openhub.api.asynch.model.TraceHeader;
+import org.openhubframework.openhub.api.asynch.model.TraceIdentifier;
+import org.openhubframework.openhub.api.exception.InternalErrorEnum;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
+import org.openhubframework.openhub.core.AbstractCoreTest;
+import org.openhubframework.openhub.core.common.validator.TraceIdentifierValidator;
 
 
 /**
@@ -137,8 +137,8 @@ public class TraceHeaderProcessorTest extends AbstractCoreTest {
             fail("request must be rejected since traceId does not have the valid value");
         } catch (Exception ex) {
             Throwable origExp = ex.getCause();
-            assertThat(origExp, instanceOf(ValidationIntegrationException.class));
-            assertThat(((ValidationIntegrationException) origExp).getError().getErrorCode(),
+            assertThat(origExp, instanceOf(ValidationException.class));
+            assertThat(((ValidationException) origExp).getError().getErrorCode(),
                     is(InternalErrorEnum.E120.getErrorCode()));
         }
     }

--- a/core/src/test/java/org/openhubframework/openhub/core/common/exception/ExceptionTranslatorTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/exception/ExceptionTranslatorTest.java
@@ -21,8 +21,8 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 
-import org.openhubframework.openhub.api.exception.IllegalDataException;
 import org.openhubframework.openhub.api.exception.InternalErrorEnum;
+import org.openhubframework.openhub.api.exception.validation.IllegalDataException;
 import org.openhubframework.openhub.test.data.ErrorTestEnum;
 
 

--- a/core/src/test/java/org/openhubframework/openhub/core/configuration/DbConfigurationParamServiceTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/configuration/DbConfigurationParamServiceTest.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.openhubframework.openhub.api.configuration.DataTypeEnum;
 import org.openhubframework.openhub.api.configuration.DbConfigurationParam;
 import org.openhubframework.openhub.api.configuration.DbConfigurationParamService;
-import org.openhubframework.openhub.api.exception.ConfigurationException;
+import org.openhubframework.openhub.api.exception.validation.ConfigurationException;
 import org.openhubframework.openhub.core.AbstractCoreDbTest;
 
 

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/AbstractOhfController.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/AbstractOhfController.java
@@ -37,7 +37,16 @@ public abstract class AbstractOhfController {
     public static final String BASE_PATH = "/api";
 
     @Autowired
-    protected MessageSource messageSource;
+    private MessageSource messageSource;
+
+    /**
+     * Gets {@link MessageSource}.
+     *
+     * @return MessageSource
+     */
+    protected final MessageSource getMessageSource() {
+        return messageSource;
+    }
 
     /**
      * Gets localization message from {@link LocaleContextHolder#getLocale() selected language}.
@@ -49,7 +58,7 @@ public abstract class AbstractOhfController {
     protected String getMessage(String code, Object... args) {
         Assert.hasText(code, "code must not be empty");
 
-        return messageSource.getMessage(code, args, LocaleContextHolder.getLocale());
+        return getMessageSource().getMessage(code, args, LocaleContextHolder.getLocale());
     }
 
     /**
@@ -62,7 +71,7 @@ public abstract class AbstractOhfController {
     protected String getMessageEN(String code, Object... args) {
         Assert.hasText(code, "code must not be empty");
 
-        return messageSource.getMessage(code, args, Locale.ENGLISH);
+        return getMessageSource().getMessage(code, args, Locale.ENGLISH);
     }
 
     /**

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/BaseRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/BaseRpc.java
@@ -17,8 +17,6 @@
 package org.openhubframework.openhub.admin.web.common.rpc;
 
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAttribute;
 
@@ -29,30 +27,17 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.util.Assert;
 
 import org.openhubframework.openhub.api.entity.Identifiable;
-import org.openhubframework.openhub.api.exception.ValidationIntegrationException;
 
 
 /**
- * Reference-able RPC entity.
- * </p>
- * There is the following lifecycle when entity is <strong>created</strong> from RPC:
- * <ol>
- *     <li>validates attributes and state of the RPC - {@link #validate()}
- *     <li>creates new entity instance - {@link #createEntityInstance(Map)}
- *     <li>creates entity - {@link #createEntity()}
- *     <li>updates attributes - {@link #updateAttributes(Identifiable, boolean)}
- * </ol>
- *
- * </p>
- * There is the following lifecycle when entity is <strong>updated</strong> from RPC:
- * <ol>
- *     <li>validates attributes and state of the RPC - {@link #validate()}
- *     <li>updates entity - {@link #updateEntity(Identifiable)}
- *     <li>updates attributes - {@link #updateAttributes(Identifiable, boolean)}
- * </ol>
+ * Reference-able read-only RPC entity.
+ * Override {@link #init()} method for custom initialization needs.
+ * <p>
+ * If you need to create/update RPC then use {@link ChangeableRpc}.
  *
  * @author <a href="mailto:petr.juza@openwise.cz">Petr Juza</a>
  * @since 2.0
+ * @see ChangeableRpc
  */
 public abstract class BaseRpc<T extends Identifiable<ID>, ID extends Serializable> implements Identifiable<ID> {
 
@@ -61,11 +46,16 @@ public abstract class BaseRpc<T extends Identifiable<ID>, ID extends Serializabl
     /**
      * Empty constructor for deserialization from XML/JSON.
      */
-    public BaseRpc() {
+    protected BaseRpc() {
         init();
     }
 
-    public BaseRpc(T entity) {
+    /**
+     * Creates RPC from specified entity.
+     *
+     * @param entity The entity
+     */
+    protected BaseRpc(T entity) {
         Assert.notNull(entity, "entity can not be null");
 
         init();
@@ -89,73 +79,6 @@ public abstract class BaseRpc<T extends Identifiable<ID>, ID extends Serializabl
      * Inits RPC => override it for specified needs.
      */
     protected void init() {
-        // nothing to implement by default
-    }
-
-    /**
-     * Validates RPC (mandatory attributes, correct object state etc.)
-     *
-     * @throws ValidationIntegrationException when there is error in input data
-     */
-    protected abstract void validate() throws ValidationIntegrationException;
-
-    /**
-     * Creates new entity instance from RPC.
-     *
-     * @param params Input parameters from client for creating new instance
-     * @return new entity instance
-     */
-    protected abstract T createEntityInstance(Map<String, ?> params);
-
-    /**
-     * Creates new entity from RPC.
-     *
-     * @return new entity
-     */
-    public final T createEntity() {
-        return createEntity(new HashMap<>());
-    }
-
-    /**
-     * Creates new entity from RPC.
-     *
-     * @param params Input parameters from client for creating new instance
-     * @return new entity
-     */
-    public final T createEntity(Map<String, ?> params) {
-        Assert.notNull(params, "params can not be null");
-
-        validate();
-
-        T entity = createEntityInstance(params);
-
-        Assert.notNull(entity, "entity can not be null");
-
-        updateAttributes(entity, true);
-
-        return entity;
-    }
-
-    /**
-     * Updates existing entity from RPC.
-     *
-     * @param entity The existing entity
-     */
-    public final void updateEntity(T entity) {
-        Assert.notNull(entity, "entity can not be null");
-
-        validate();
-
-        updateAttributes(entity, false);
-    }
-
-    /**
-     * Updates attributes of specified entity from RPC values.
-     *
-     * @param entity The entity
-     * @param created {@code true} if new entity is created or {@code false} if entity is updated
-     */
-    protected void updateAttributes(T entity, boolean created) {
         // nothing to implement by default
     }
 

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/ChangeableRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/ChangeableRpc.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.common.rpc;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+import org.springframework.util.Assert;
+import org.springframework.validation.AbstractPropertyBindingResult;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ValidationUtils;
+
+import org.openhubframework.openhub.api.common.Constraints;
+import org.openhubframework.openhub.api.entity.Identifiable;
+import org.openhubframework.openhub.api.exception.validation.IllegalDataException;
+import org.openhubframework.openhub.api.exception.validation.InputValidationException;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
+
+
+/**
+ * RPC that can be created or updated. {@link BaseRpc} is for readonly RPCs.
+ * <p>
+ * There is the following lifecycle when entity is <strong>created</strong> from RPC -
+ * calling {@link #createEntity()} or {@link #createEntity(BindingResult)} or {@link #createEntity(BindingResult, Map)}:
+ * <ol>
+ *     <li>validates attributes and state of the RPC - {@link #validate(BindingResult, Identifiable)}
+ *     <li>creates new entity instance - {@link #createEntityInstance(Map)}
+ *     <li>updates attributes - {@link #updateAttributes(Identifiable, boolean)}, where second parameter is {@code true}
+ * </ol>
+ *
+ * </p>
+ * There is the following lifecycle when entity is <strong>updated</strong> from RPC -
+ * calling {@link #updateEntity(Identifiable)} or {@link #updateEntity(Identifiable, BindingResult)}:
+ * <ol>
+ *     <li>validates attributes and state of the RPC - {@link #validate(BindingResult, Identifiable)}
+ *     <li>updates attributes - {@link #updateAttributes(Identifiable, boolean)}, where second parameter is {@code false}
+ * </ol>
+ * </p>
+ *
+ * @author Petr Juza
+ * @since 2.0
+ */
+public abstract class ChangeableRpc<T extends Identifiable<ID>, ID extends Serializable> extends BaseRpc<T, ID> {
+
+    /**
+     * Empty constructor for deserialization from XML/JSON.
+     */
+    protected ChangeableRpc() {
+    }
+
+    /**
+     * Creates RPC from specified entity.
+     *
+     * @param entity The entity
+     */
+    protected ChangeableRpc(T entity) {
+        super(entity);
+    }
+
+    /**
+     * Validates RPC.
+     *
+     * @param errors Binding/validation errors
+     * @param updateEntity {@code null} if new entity is created otherwise entity that is updated
+     * @throws ValidationException when there is error in input data
+     */
+    private void doValidation(BindingResult errors, @Nullable T updateEntity) throws ValidationException {
+        Assert.notNull(errors, "errors can not be null");
+
+        try {
+            validate(errors, updateEntity);
+        } catch (Exception ex) {
+            if (!(ex instanceof ValidationException)) {
+                // no validation exception => wrap it by ValidationException
+                throw new IllegalDataException("validation of the following object failed: " + toString(), ex);
+            }
+        }
+
+        if (errors.hasErrors()) {
+            throw new InputValidationException(errors);
+        }
+    }
+
+    /**
+     * Validates RPC (mandatory attributes, correct object state etc.).
+     * <p>
+     * There are the following possibilities how to make validation:
+     * <ul>
+     *     <li>add errors to {@link BindingResult errors} (e.g. use {@link ValidationUtils}).
+     *          If it has errors then {@link InputValidationException} will be thrown
+     *     <li>throw {@link ValidationException} itself (e.g. use {@link Constraints} for asserts)
+     *     <li>if exception is thrown and it's not type of {@link ValidationException} then
+     *          original exception will be wrapped by {@link IllegalDataException}
+     *     <li>use <a href="http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#validation-beanvalidation-overview">
+     *         JSR-303 Bean Validation API</a>
+     * </ul>
+     *
+     * @param errors Binding/validation errors
+     * @param updateEntity {@code null} if new entity is created otherwise entity that is updated
+     * @throws ValidationException when there is error in input data
+     */
+    protected abstract void validate(BindingResult errors, @Nullable T updateEntity) throws ValidationException;
+
+    /**
+     * Creates new entity instance from RPC.
+     *
+     * @param params Input parameters from client for creating new instance
+     * @return new entity instance
+     */
+    protected abstract T createEntityInstance(Map<String, ?> params);
+
+    /**
+     * Creates new entity from RPC.
+     *
+     * @return new entity
+     */
+    public final T createEntity() {
+        return createEntity(createBeanPropertyBindingResult(), new HashMap<>());
+    }
+
+    /**
+   	 * Create the {@link AbstractPropertyBindingResult} instance using standard JavaBean property access.
+   	 */
+   	protected AbstractPropertyBindingResult createBeanPropertyBindingResult() {
+   	    return new BeanPropertyBindingResult(this, getObjectName());
+    }
+
+    /**
+     * Gets object's name.
+     * Override it or {@link Class#getSimpleName()} simple class name} will be returned.
+     *
+     * @return object's name
+     */
+    public String getObjectName() {
+        String name = this.getClass().getSimpleName();
+        return name.substring(0, 1).toUpperCase() + name.substring(1);
+    }
+
+    /**
+     * Creates new entity from RPC.
+     *
+     * @param bindingResult Binding results
+     * @return new entity
+     */
+    public final T createEntity(BindingResult bindingResult) {
+        return createEntity(bindingResult, new HashMap<>());
+    }
+
+    /**
+     * Creates new entity from RPC.
+     *
+     * @param bindingResult Binding results
+     * @param params Input parameters from client for creating new instance
+     * @return new entity
+     */
+    public final T createEntity(BindingResult bindingResult, Map<String, ?> params) {
+        Assert.notNull(bindingResult, "bindingResult can not be null");
+        Assert.notNull(params, "params can not be null");
+
+        doValidation(bindingResult,null);
+
+        T entity = createEntityInstance(params);
+
+        Assert.notNull(entity, "entity can not be null");
+
+        updateAttributes(entity, true);
+
+        return entity;
+    }
+
+    /**
+     * Updates existing entity from RPC.
+     *
+     * @param entity The existing entity
+     */
+    public final void updateEntity(T entity) {
+        updateEntity(entity, createBeanPropertyBindingResult());
+    }
+
+    /**
+     * Updates existing entity from RPC.
+     *
+     * @param entity The existing entity
+     * @param bindingResult Binding results
+     */
+    public final void updateEntity(T entity, BindingResult bindingResult) {
+        Assert.notNull(bindingResult, "bindingResult can not be null");
+        Assert.notNull(entity, "entity can not be null");
+
+        doValidation(bindingResult, entity);
+
+        updateAttributes(entity, false);
+    }
+
+    /**
+     * Updates attributes of specified entity from RPC values.
+     *
+     * @param entity The entity
+     * @param created {@code true} if new entity is created or {@code false} if entity is updated
+     */
+    protected void updateAttributes(T entity, boolean created) {
+        // nothing to implement by default
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/FieldInputErrorRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/FieldInputErrorRpc.java
@@ -18,6 +18,8 @@ package org.openhubframework.openhub.admin.web.common.rpc;
 
 import javax.annotation.Nullable;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.util.Assert;
 
 
@@ -29,20 +31,38 @@ import org.springframework.util.Assert;
  */
 public class FieldInputErrorRpc {
 
+    private final String objectName;
+
     private final String field;
 
     private final String code;
 
     private final String message;
 
-    public FieldInputErrorRpc(String field, String code, String message) {
+    private final Object rejectedValue;
+
+    public FieldInputErrorRpc(String objectName, String field, String code, String message) {
+        this(objectName, field, null, code, message);
+    }
+
+    public FieldInputErrorRpc(String objectName, String field, @Nullable Object rejectedValue, String code, String message) {
+        Assert.hasText(objectName, "objectName must not be empty");
         Assert.hasText(field, "field must not be empty");
         Assert.hasText(code, "code must not be empty");
         Assert.hasText(message, "message must not be empty");
 
+        this.objectName = objectName;
         this.field = field;
         this.code = code;
         this.message = message;
+        this.rejectedValue = rejectedValue;
+    }
+
+    /**
+     * Gets + objectName: 'category' - object name, e.g. category.
+     */
+    public String getObjectName() {
+        return objectName;
     }
 
     /**
@@ -72,5 +92,24 @@ public class FieldInputErrorRpc {
     @Nullable
     public String getMessageI18n() {
         return getMessage();
+    }
+
+    /**
+     * Gets rejectedValue: '' (string,) - rejected field value.
+     */
+    @Nullable
+    public Object getRejectedValue() {
+        return rejectedValue;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("objectName", objectName)
+                .append("field", field)
+                .append("rejectedValue", rejectedValue)
+                .append("code", code)
+                .append("message", message)
+                .toString();
     }
 }

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/ValidationFaultRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/ValidationFaultRpc.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.springframework.http.HttpStatus;
 
-import org.openhubframework.openhub.api.exception.ValidationIntegrationException;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
 
 
 /**
@@ -38,11 +38,11 @@ public class ValidationFaultRpc extends GeneralFaultRpc {
 
     private final List<FieldInputErrorRpc> inputFields = new ArrayList<>();
 
-    public ValidationFaultRpc(ValidationIntegrationException ex) {
+    public ValidationFaultRpc(ValidationException ex) {
         super(HttpStatus.BAD_REQUEST, ex);
     }
 
-    public ValidationFaultRpc(HttpStatus status, ValidationIntegrationException ex) {
+    public ValidationFaultRpc(HttpStatus status, ValidationException ex) {
         super(status, ex);
     }
 

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/configuration/rpc/DbConfigurationParamRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/configuration/rpc/DbConfigurationParamRpc.java
@@ -18,16 +18,21 @@ package org.openhubframework.openhub.admin.web.configuration.rpc;
 
 import java.util.Map;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.eclipse.core.runtime.Assert;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.Assert;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.annotation.Validated;
 
-import org.openhubframework.openhub.admin.web.common.rpc.BaseRpc;
+import org.openhubframework.openhub.admin.web.common.rpc.ChangeableRpc;
+import org.openhubframework.openhub.api.common.Constraints;
 import org.openhubframework.openhub.api.configuration.DbConfigurationParam;
-import org.openhubframework.openhub.api.exception.ValidationIntegrationException;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
 
 
 /**
@@ -37,7 +42,8 @@ import org.openhubframework.openhub.api.exception.ValidationIntegrationException
  * @since 2.0
  */
 @XmlRootElement
-public class DbConfigurationParamRpc extends BaseRpc<DbConfigurationParam, String> {
+@Validated
+public class DbConfigurationParamRpc extends ChangeableRpc<DbConfigurationParam, String> {
 
     /**
      * Converts {@link DbConfigurationParam} to {@link DbConfigurationParamRpc}.
@@ -53,11 +59,13 @@ public class DbConfigurationParamRpc extends BaseRpc<DbConfigurationParam, Strin
     /**
      * code: ohf.server.localhostUri.check (string) - unique code of one configuration parameter
      */
+    @NotNull
     private String code;
 
     /**
      * categoryCode: core.server (string) - unique code for specific configuration scope/category
      */
+    @NotNull
     private String categoryCode;
 
     /**
@@ -80,6 +88,7 @@ public class DbConfigurationParamRpc extends BaseRpc<DbConfigurationParam, Strin
              + `BOOL`
              + `FILE`
      */
+    @NotNull
     private String dataType;
 
     /**
@@ -117,8 +126,11 @@ public class DbConfigurationParamRpc extends BaseRpc<DbConfigurationParam, Strin
     }
 
     @Override
-    protected void validate() throws ValidationIntegrationException {
-        //TODO PJUZA make validation
+    protected void validate(BindingResult errors, @Nullable DbConfigurationParam updateEntity) throws ValidationException {
+        if (updateEntity != null) {
+            ValidationUtils.rejectIfEmpty(errors, "code", "field.required");
+            Constraints.state(getCode().equals(updateEntity.getCode()), "codes must be equal");
+        }
     }
 
     @Override

--- a/web-admin/src/main/java/org/openhubframework/openhub/web/config/WebContextConfig.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/web/config/WebContextConfig.java
@@ -139,7 +139,6 @@ public class WebContextConfig {
     /**
      * Defines localized messages for admin console.
      */
-    //TODO PJUZA configure MessageSource as in WIS ?
     @Bean
     @ConditionalOnMissingBean
     public ReloadableResourceBundleMessageSource messageSource() {

--- a/web-admin/src/main/resources/messages/messages_cs.properties
+++ b/web-admin/src/main/resources/messages/messages_cs.properties
@@ -1,3 +1,6 @@
+# common validation messages
+field.required = Povinn\u00FD atribut nen\u00ED vypln\u011Bn\u00FD.
+
 # common
 return = N\u00E1vrat
 submit = Odeslat

--- a/web-admin/src/main/resources/messages/messages_en.properties
+++ b/web-admin/src/main/resources/messages/messages_en.properties
@@ -1,3 +1,6 @@
+# common validation messages
+field.required = Mandatory field is not filled
+
 # common
 return = Return
 submit = Submit


### PR DESCRIPTION
**REST base - validations**

I introduced validation model for MVC/REST applications. Main idea was to be able validate RPC objects and re-use from [Spring validation model](http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#validation-beanvalidation) as much as possible:
- I changed RPC API - _ChangeableRpc_: added _BindingResult_ to specific methods
- added _org.openhubframework.openhub.api.exception.validation.InputValidationException_ (renamed _ValidationIntegrationException_ -> _ValidationException_)
- changed _ChangeableRpc#validate_ - now there are several possibilities how to make validation:
  - add errors to _BindingResult_ errors (e.g. use _ValidationUtils_). If it has errors then _InputValidationException_ will be thrown
  - throw _ValidationException_ itself (e.g. use _Constraints_ for asserts)
  - if exception is thrown and it's not type of _ValidationException_ then original exception will be wrapped by _IllegalDataException_
  - use [JSR-303 Bean Validation API](http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#validation-beanvalidation-overview)

Focus on ChangeableRpc, ExceptionRestHandler#onValidationException and DbConfigurationController#update