### PR TITLE
OHFJIRA-68 - No routes are load in CamelContext

### DIFF
--- a/core/src/main/java/org/openhubframework/openhub/core/confcheck/ConfigurationChecker.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/confcheck/ConfigurationChecker.java
@@ -16,10 +16,7 @@
 
 package org.openhubframework.openhub.core.confcheck;
 
-import static org.openhubframework.openhub.api.configuration.CoreProps.ENDPOINTS_INCLUDE_PATTERN;
-import static org.openhubframework.openhub.api.configuration.CoreProps.REQUEST_SAVING_ENDPOINT_FILTER;
-import static org.openhubframework.openhub.api.configuration.CoreProps.SERVER_LOCALHOST_URI;
-import static org.openhubframework.openhub.api.configuration.CoreProps.SERVER_LOCALHOST_URI_CHECK;
+import static org.openhubframework.openhub.api.configuration.CoreProps.*;
 import static org.openhubframework.openhub.api.route.RouteConstants.HTTP_URI_PREFIX;
 
 import java.io.IOException;
@@ -39,7 +36,6 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.util.Assert;
 import org.springframework.web.context.WebApplicationContext;
 
 import org.openhubframework.openhub.api.configuration.ConfigurableValue;
@@ -111,9 +107,6 @@ public class ConfigurationChecker implements ApplicationListener<ApplicationRead
      */
     void checkConfiguration(ApplicationContext context) {
         LOG.debug("Checking configuration validity ...");
-
-        Assert.state(context instanceof WebApplicationContext && context.getParent() != null,
-                "configuration checking is enabled for web context only");
 
         try {
             if (checkUrl.getValue()) {

--- a/web-admin/src/main/java/org/openhubframework/openhub/OpenHubApplication.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/OpenHubApplication.java
@@ -37,19 +37,19 @@ import org.openhubframework.openhub.common.log.LogContextFilter;
 import org.openhubframework.openhub.core.config.CamelConfig;
 import org.openhubframework.openhub.core.config.JpaConfig;
 import org.openhubframework.openhub.core.config.WebServiceConfig;
-import org.openhubframework.openhub.web.config.CamelRoutesConfig;
+import org.openhubframework.openhub.config.CamelRoutesConfig;
 import org.openhubframework.openhub.web.config.GlobalSecurityConfig;
-import org.openhubframework.openhub.web.config.WebContextConfig;
+import org.openhubframework.openhub.config.WebConfigurer;
 import org.openhubframework.openhub.web.config.WebSecurityConfig;
 
 
 /**
  * OpenHub application configuration.
  * <p/>
- * This class configures root Spring context and {@link WebContextConfig web child} context.
+ * This class configures root Spring context and {@link WebConfigurer web child} context.
  *
  * @author Petr Juza
- * @see WebContextConfig
+ * @see WebConfigurer
  * @see GlobalSecurityConfig
  * @see WebSecurityConfig
  * @see CamelRoutesConfig
@@ -65,10 +65,10 @@ import org.openhubframework.openhub.web.config.WebSecurityConfig;
 @ComponentScan(basePackages = {
         "org.openhubframework.openhub.common",
         "org.openhubframework.openhub.core",
-        "org.openhubframework.openhub.modules"
+        "org.openhubframework.openhub.modules",
+        "org.openhubframework.openhub.config"
 },
         excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebContextConfig.class),
                 @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = AutoConfiguration.class),
                 @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = CamelConfiguration.class)
         })
@@ -128,8 +128,7 @@ public class OpenHubApplication extends SpringBootServletInitializer implements 
 
     private static SpringApplicationBuilder createOpenHubApplicationBuilder() {
         return new SpringApplicationBuilder()
-                .parent(OpenHubApplication.class)
-                .child(WebContextConfig.class);
+                .parent(OpenHubApplication.class);
     }
     
 }

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/config/AdminMvcConfig.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/config/AdminMvcConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.web.config;
+package org.openhubframework.openhub.admin.config;
 
 import static org.springframework.util.StringUtils.hasText;
 

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/config/AdminSecurityConfig.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/config/AdminSecurityConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.web.config;
+package org.openhubframework.openhub.admin.config;
 
 import static org.openhubframework.openhub.api.route.RouteConstants.WEB_URI_PREFIX;
 import static org.openhubframework.openhub.web.config.GlobalSecurityConfig.DEFAULT_PATH_PATTERN;
@@ -28,6 +28,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
 import org.openhubframework.openhub.api.route.RouteConstants;
+import org.openhubframework.openhub.web.config.GlobalSecurityConfig;
+import org.openhubframework.openhub.web.config.WebSecurityConfig;
 
 
 /**

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/config/CustomFreemarkerConfig.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/config/CustomFreemarkerConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.web.config;
+package org.openhubframework.openhub.admin.config;
 
 import freemarker.ext.jsp.TaglibFactory;
 import freemarker.template.ObjectWrapper;

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/config/WebAdminConfigurer.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/config/WebAdminConfigurer.java
@@ -1,0 +1,101 @@
+package org.openhubframework.openhub.admin.config;
+
+import static org.openhubframework.openhub.api.route.RouteConstants.WEB_URI_PREFIX_MAPPING;
+
+import java.util.Locale;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.i18n.SessionLocaleResolver;
+
+import org.openhubframework.openhub.api.route.RouteConstants;
+import org.openhubframework.openhub.web.RequestResponseLoggingFilter;
+
+/**
+ * Web configurer which is responsible for configuration of web admin client.
+ *
+ * @author Tomas Hanus
+ * @see AdminMvcConfig
+ * @see AdminSecurityConfig
+ * @see CustomFreemarkerConfig
+ * @since 2.0
+ */
+@Configuration
+public class WebAdminConfigurer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WebAdminConfigurer.class);
+
+    /**
+     * The ID of web context.
+     */
+    public static final String WEB_CONTEXT_ID = "WebContext";
+
+    /**
+     * Registers {@link RequestResponseLoggingFilter}.
+     */
+    @Bean
+    public FilterRegistrationBean loggingRest() {
+        LOG.info("REQ/RES logging initialization");
+
+        RequestResponseLoggingFilter filter = new RequestResponseLoggingFilter();
+        filter.setLogUnsupportedContentType(false);
+        final FilterRegistrationBean bean = new FilterRegistrationBean(filter);
+        // we use logging filter only for administration endpoints to avoid duplication log events
+        bean.addUrlPatterns(WEB_URI_PREFIX_MAPPING);
+
+        return bean;
+    }
+
+    /**
+     * Defines localized messages for admin console.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public ReloadableResourceBundleMessageSource messageSource() {
+        ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
+        messageSource.setBasename("classpath:messages/messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        return messageSource;
+    }
+
+    /**
+     * Defines default {@link LocaleResolver}.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public LocaleResolver localeResolver() {
+        SessionLocaleResolver localeResolver = new SessionLocaleResolver();
+        localeResolver.setDefaultLocale(Locale.ENGLISH);
+        return localeResolver;
+    }
+
+    /**
+     * Configures servlet for admin interface of OpenHub.
+     *
+     * @param context           current context
+     * @param dispatcherServlet as actually registered dispatcher
+     * @return registration bean of {@link DispatcherServlet} to handling {@link RouteConstants#WEB_URI_PREFIX_MAPPING}.
+     */
+    @Bean(name = WEB_CONTEXT_ID)
+    @ConditionalOnMissingBean(name = WEB_CONTEXT_ID)
+    public ServletRegistrationBean adminServlet(
+            ConfigurableApplicationContext context,
+            DispatcherServlet dispatcherServlet) {
+
+        ServletRegistrationBean bean = new ServletRegistrationBean(dispatcherServlet);
+        // sets corresponding ID (name) of web context
+        context.setId(WEB_CONTEXT_ID);
+        bean.addUrlMappings(WEB_URI_PREFIX_MAPPING);
+
+        return bean;
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/config/package-info.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/config/package-info.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package place holder for admin web pages configuration.
+ *
+ * @author Roman Havlicek
+ * @since 2.0
+ */
+package org.openhubframework.openhub.admin.config;

--- a/web-admin/src/main/java/org/openhubframework/openhub/config/CamelRoutesConfig.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/config/CamelRoutesConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.web.config;
+package org.openhubframework.openhub.config;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;

--- a/web-admin/src/main/java/org/openhubframework/openhub/config/package-info.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/config/package-info.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package place holder for base spring configurations.
+ *
+ * @author Roman Havlicek
+ * @since 2.0
+ */
+package org.openhubframework.openhub.config;

--- a/web-admin/src/main/java/org/openhubframework/openhub/web/config/WebServiceConfigurer.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/web/config/WebServiceConfigurer.java
@@ -1,19 +1,3 @@
-/*
- *  Copyright 2017 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.openhubframework.openhub.web.config;
 
 import org.apache.camel.component.servlet.CamelHttpTransportServlet;
@@ -28,17 +12,20 @@ import org.springframework.ws.transport.http.WebServiceMessageReceiverHandlerAda
 import org.openhubframework.openhub.api.route.RouteConstants;
 import org.openhubframework.openhub.core.common.ws.ErrorCodeAwareWebServiceMessageReceiverHandlerAdapter;
 
-
 /**
- * Web configurer which is responsible for configuration of web runtime layer of OpenHub, for example servlet
- * registration of camel connectors.
+ * Web configurer which is responsible for servlet registration of camel connectors.
  *
  * @author Tomas Hanus
- * @see WebContextConfig
+ * @see WebSecurityConfig
  * @since 2.0
  */
 @Configuration
-public class WebConfigurer {
+public class WebServiceConfigurer {
+
+    /**
+     * The ID of webservice context.
+     */
+    public static final String WS_CONTEXT_ID = "WsContext";
 
     /**
      * Configures servlet for HTTP communication.
@@ -69,7 +56,8 @@ public class WebConfigurer {
     public ServletRegistrationBean dispatcherWsRegistration(ApplicationContext applicationContext) {
         MessageDispatcherServlet servlet = new MessageDispatcherServlet();
         servlet.setApplicationContext(applicationContext);
-        
+        servlet.setContextId(WS_CONTEXT_ID);
+
         return new ServletRegistrationBean(servlet, RouteConstants.WS_URI_PREFIX_MAPPING);
     }
 


### PR DESCRIPTION
Problem:
Loading all routes is in web child context, but camel context starts in root application context. 

Solution:
Move route loading (class CamelRoutesConfig) and base security config (GlobalSecurityConfig and WebSecurityConfig) from child web context into root context. Remove child context. Everything now is in root context.

JIRA:
https://openhubframework.atlassian.net/browse/OHFJIRA-68