### PR TITLE
OHFJIRA-52 list of exposed webservices

### DIFF
--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/services/wsdl/rest/WsdlController.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/services/wsdl/rest/WsdlController.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.services.wsdl.rest;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.openhubframework.openhub.admin.web.common.AbstractOhfController;
+import org.openhubframework.openhub.admin.web.common.rpc.CollectionWrapper;
+import org.openhubframework.openhub.admin.web.services.wsdl.rpc.WsdlInfoRpc;
+import org.openhubframework.openhub.api.route.RouteConstants;
+import org.openhubframework.openhub.core.common.ws.WsdlRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * Controller serving list of exposed webservices contracts - wsdl.
+ *
+ * @author Karel Kovarik
+ */
+@RestController(WsdlController.BEAN_NAME)
+@RequestMapping(value = WsdlController.REST_URI)
+public class WsdlController extends AbstractOhfController {
+
+    /**
+     * Base REST uri for the controller.
+     */
+    public static final String REST_URI = BASE_PATH + "/services/wsdl";
+
+    /**
+     * Suffix for all wsdl files.
+     */
+    private static final String WSDL_SUFFIX = ".wsdl";
+
+    /**
+     * Custom bean name.
+     */
+    public static final String BEAN_NAME = "WsdlRestController";
+
+    @Autowired
+    private WsdlRegistry wsdlRegistry;
+
+    /**
+     * Get list of exposed wsdl contracts.
+     * @param request the input httpServletRequest.
+     * @return list of {@link WsdlInfoRpc} objects wrapped in the {@link CollectionWrapper}.
+     */
+    @GetMapping(produces = {"application/xml", "application/json"})
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public CollectionWrapper<WsdlInfoRpc> list(final HttpServletRequest request) {
+        return new CollectionWrapper<>(
+                wsdlRegistry.getWsdls().stream()
+                        // sort by beanName, mainly to have stable order
+                        .sorted(Comparator.naturalOrder())
+                        // map to Rpc object
+                        .map(beanName -> new WsdlInfoRpc(beanName, wsdlUrl(request, beanName)))
+                        .collect(Collectors.toList()));
+    }
+
+    // create url of wsdl for webservice
+    private static String wsdlUrl(final HttpServletRequest request, final String beanName) {
+        return getBaseUrl(request) + RouteConstants.WS_URI_PREFIX + beanName + WSDL_SUFFIX;
+    }
+
+    // baseUrl of the server - like http://localhost:8080
+    private static String getBaseUrl(final HttpServletRequest request) {
+        URL requestURL;
+        try {
+            requestURL = new URL(request.getRequestURL().toString());
+        } catch (final MalformedURLException e) {
+            // should not happen, request is expected to have valid requestURL
+            throw new RuntimeException("Not valid request.requestURL for parsing:", e);
+        }
+        final String port = requestURL.getPort() == -1 ? "" : ":" + requestURL.getPort();
+        return requestURL.getProtocol() + "://" + requestURL.getHost() + port;
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/services/wsdl/rest/package-info.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/services/wsdl/rest/package-info.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * REST endpoints for REST wsdl related operation.
+ *
+ * @author Karel Kovarik
+ * @since 2.0
+ */
+package org.openhubframework.openhub.admin.web.services.wsdl.rest;

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/services/wsdl/rpc/WsdlInfoRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/services/wsdl/rpc/WsdlInfoRpc.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.services.wsdl.rpc;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+
+/**
+ * Info about exposed webservice.
+ *
+ * @author Karel Kovarik
+ */
+@XmlRootElement
+public class WsdlInfoRpc {
+
+    private final String name;
+    private final String wsdl;
+
+    /**
+     * All argument constructor.
+     * @param name the name of webservice.
+     * @param wsdl the link to wsdl.
+     */
+    public WsdlInfoRpc(String name, String wsdl) {
+        this.name = name;
+        this.wsdl = wsdl;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getWsdl() {
+        return wsdl;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("name", name)
+                .append("wsdl", wsdl)
+                .toString();
+    }
+}

--- a/web-admin/src/test/java/org/openhubframework/openhub/admin/web/services/wsdl/rest/WsdlControllerTest.java
+++ b/web-admin/src/test/java/org/openhubframework/openhub/admin/web/services/wsdl/rest/WsdlControllerTest.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.services.wsdl.rest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.openhubframework.openhub.test.rest.TestRestUtils.createGetUrl;
+import static org.openhubframework.openhub.test.rest.TestRestUtils.toUrl;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.openhubframework.openhub.admin.AbstractAdminModuleRestTest;
+import org.openhubframework.openhub.core.common.ws.WsdlRegistry;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+
+/**
+ * Simple test suite for {@link WsdlController}.
+ *
+ * @author Karel Kovarik
+ */
+public class WsdlControllerTest extends AbstractAdminModuleRestTest {
+
+    private static final String ROOT_URI = WsdlController.REST_URI;
+
+    // mocked wsdlRegistry, not to have only empty list
+    @MockBean
+    private WsdlRegistry wsdlRegistry;
+
+    @Test
+    public void wsdlList() throws Exception {
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI);
+
+        Mockito.when(wsdlRegistry.getWsdls())
+                .thenReturn(Collections.singletonList("hello"));
+
+        // GET /api/services/wsdl
+        mockMvc.perform(get(toUrl(uriBuilder))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("data.[0].name", is("hello")))
+                .andExpect(jsonPath("data.[0].wsdl", is("http://localhost/ws/hello.wsdl")))
+        ;
+    }
+}


### PR DESCRIPTION
### ABOUT 
Overview of exposed Webservices. See related JIRA task for more info: https://openhubframework.atlassian.net/browse/OHFJIRA-52

### CHANGES
* added new REST endpoint GET /api/ws with simple test. It does reuse WsdlRegistry functionality.