### PR TITLE
OHFJIRA-51: Cluster node management API.

### DIFF
--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/AbstractNode.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/AbstractNode.java
@@ -1,5 +1,7 @@
 package org.openhubframework.openhub.api.entity;
 
+import javax.annotation.Nullable;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -14,6 +16,17 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @since 2.0
  */
 public abstract class AbstractNode implements Node {
+
+    @Nullable
+    @Override
+    public Long getId() {
+        return getNodeId();
+    }
+
+    @Override
+    public void setId(@Nullable Long id) {
+        throw new UnsupportedOperationException("It is not possible to update unique identifier");
+    }
 
     @Override
     public boolean isStopped() {

--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/Node.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/Node.java
@@ -15,7 +15,7 @@ import org.openhubframework.openhub.api.common.HumanReadable;
  * @see MutableNode
  * @since 2.0
  */
-public interface Node extends HumanReadable {
+public interface Node extends HumanReadable, Identifiable<Long> {
 
     /**
      * Is node for this instance stopping?

--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/node/NodeService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/node/NodeService.java
@@ -32,7 +32,7 @@ public interface NodeService {
     Node update(Node node, ChangeNodeCallback changeNodeCallback);
 
     /**
-     * Update existing {@link Node}.
+     * Delete existing {@link Node}.
      *
      * @param node node
      */

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/cluster/node/rest/ClusterNodeController.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/cluster/node/rest/ClusterNodeController.java
@@ -1,0 +1,118 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.cluster.node.rest;
+
+import java.util.List;
+import javax.validation.Valid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.Assert;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import org.openhubframework.openhub.admin.web.cluster.node.rpc.NodeRpc;
+import org.openhubframework.openhub.admin.web.common.AbstractOhfController;
+import org.openhubframework.openhub.admin.web.common.rpc.CollectionWrapper;
+import org.openhubframework.openhub.api.common.Constraints;
+import org.openhubframework.openhub.api.entity.Node;
+import org.openhubframework.openhub.api.exception.NoDataFoundException;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
+import org.openhubframework.openhub.spi.node.NodeService;
+
+
+/**
+ * REST controller with operations of {@link org.openhubframework.openhub.api.entity.Node} entity.
+ *
+ * @author Tomas Hanus
+ * @since 2.0
+ */
+@RestController
+@RequestMapping(value = ClusterNodeController.REST_URI)
+public class ClusterNodeController extends AbstractOhfController {
+
+    public static final String REST_URI = BASE_PATH + "/cluster/nodes";
+
+    @Autowired
+    private NodeService nodeService;
+
+    /**
+     * Gets list of all cluster nodes.
+     *
+     * @return list of nodes
+     */
+    @RequestMapping(method = RequestMethod.GET, produces = {"application/xml", "application/json"})
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public CollectionWrapper<NodeRpc> findAll() {
+        List<Node> nodes = nodeService.getAllNodes();
+
+        return new CollectionWrapper<>(new NodeRpc.NodeRpcConverter(), nodes);
+    }
+
+    /**
+     * Gets {@link NodeRpc} by ID.
+     *
+     * @param id The {@link NodeRpc#getId()}
+     * @return node entity
+     * @throws NoDataFoundException if entity not found
+     */
+    @RequestMapping(value = "/{id}", method = RequestMethod.GET, produces = {"application/xml", "application/json"})
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public NodeRpc getById(@PathVariable final Long id) throws NoDataFoundException {
+        return new NodeRpc(nodeService.getNodeById(id));
+    }
+
+    /**
+     * Updates existing {@link NodeRpc}.
+     *
+     * @param id      as identifier of {@link NodeRpc}
+     * @param nodeRpc The {@link NodeRpc}
+     * @throws ValidationException  if input object has wrong values
+     * @throws NoDataFoundException entity not found for update
+     */
+    @RequestMapping(value = "/{id}", method = RequestMethod.PUT, produces = {"application/xml", "application/json"})
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ResponseBody
+    public void update(@PathVariable final Long id, @RequestBody @Valid final NodeRpc nodeRpc,
+            BindingResult errors) throws ValidationException, NoDataFoundException {
+
+        Assert.notNull(nodeRpc, "nodeRpc can not be null");
+        if (nodeRpc.getId() != null) {
+            Constraints.state(id.equals(nodeRpc.getId()), "IDs must be equal");
+        }
+
+        // get entity to update it
+        Node dbNode = nodeService.getNodeById(id);
+
+        // save entity
+        nodeService.update(dbNode, new NodeRpc.ChangeCallback(errors, nodeRpc));
+    }
+
+    /**
+     * Deletes existing {@link NodeRpc}.
+     *
+     * @param id as identifier of {@link NodeRpc}
+     */
+    @RequestMapping(value = "/{id}", method = RequestMethod.DELETE, produces = {"application/xml", "application/json"})
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ResponseBody
+    public void delete(@PathVariable final Long id) {
+        nodeService.delete(nodeService.getNodeById(id));
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/cluster/node/rpc/NodeRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/cluster/node/rpc/NodeRpc.java
@@ -1,0 +1,237 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.cluster.node.rpc;
+
+import static org.springframework.util.StringUtils.hasText;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.Assert;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+
+import org.openhubframework.openhub.admin.web.common.rpc.ChangeableRpc;
+import org.openhubframework.openhub.api.entity.MutableNode;
+import org.openhubframework.openhub.api.entity.Node;
+import org.openhubframework.openhub.api.entity.NodeState;
+import org.openhubframework.openhub.api.exception.validation.IllegalDataException;
+import org.openhubframework.openhub.api.exception.validation.InputValidationException;
+import org.openhubframework.openhub.api.exception.validation.ValidationException;
+import org.openhubframework.openhub.spi.node.ChangeNodeCallback;
+
+
+/**
+ * RPC of {@link Node} entity.
+ *
+ * @author Tomas Hanus
+ * @since 2.0
+ */
+@XmlRootElement
+@Validated
+public class NodeRpc extends ChangeableRpc<Node, Long> {
+
+    /**
+     * Converts {@link Node} to {@link NodeRpc}.
+     */
+    public static class NodeRpcConverter implements Converter<Node, NodeRpc> {
+
+        @Override
+        public NodeRpc convert(Node expr) {
+            return new NodeRpc(expr);
+        }
+    }
+
+    /**
+     * Execution callback used to update entity.
+     */
+    public static class ChangeCallback implements ChangeNodeCallback {
+
+        private final BindingResult bindingResult;
+        private final NodeRpc nodeRpc;
+
+        /**
+         * Creates change callback for {@link NodeRpc}.
+         *
+         * @param nodeRpc to be updated in database
+         */
+        public ChangeCallback(BindingResult bindingResult, NodeRpc nodeRpc) {
+            this.bindingResult = bindingResult;
+            this.nodeRpc = nodeRpc;
+        }
+
+        @Override
+        public void updateNode(final MutableNode node) {
+
+            node.setName(nodeRpc.getName());
+            node.setDescription(nodeRpc.getDescription());
+
+            // condition translation
+            if (hasText(nodeRpc.getState())) {
+                final NodeState nodeState = NodeState.valueOf(nodeRpc.getState());
+                switch (nodeState) {
+                    case RUN:
+                        node.setRunState();
+                        break;
+                    case HANDLES_EXISTING_MESSAGES:
+                        node.setHandleOnlyExistingMessageState();
+                        break;
+                    case STOPPED:
+                        node.setStoppedState();
+                        break;
+                }
+            }
+
+            // validation phase
+            try {
+                nodeRpc.preSaveValidation(bindingResult, node);
+            } catch (Exception ex) {
+                if (!(ex instanceof ValidationException)) {
+                    // no validation exception => wrap it by ValidationException
+                    throw new IllegalDataException("validation of the following object failed: " + toString(), ex);
+                }
+            }
+
+            if (bindingResult.hasErrors()) {
+                throw new InputValidationException(bindingResult);
+            }
+        }
+    }
+
+    /**
+     * Identifier.
+     */
+    private Long id;
+
+    /**
+     * Unique node code.
+     */
+    private String code;
+
+    /**
+     * Unique node name.
+     */
+    @NotEmpty
+    private String name;
+
+    /**
+     * Description.
+     */
+    private String description;
+
+    /**
+     * state (enum[string]): state of node
+     * + Members
+     * + `RUN`
+     * + `HANDLES_EXISTING_MESSAGES`
+     * + `STOPPED`
+     */
+    @NotEmpty
+    private String state;
+
+    protected NodeRpc() {
+        // for XML NodeRpc
+    }
+
+    /**
+     * Creates {@link NodeRpc} based upon {@link Node}.
+     *
+     * @param entity of node
+     */
+    public NodeRpc(Node entity) {
+        super(entity);
+
+        this.id = entity.getId();
+        this.code = entity.getCode();
+        this.name = entity.getName();
+        this.description = entity.getDescription();
+        this.state = entity.getState().name();
+    }
+
+    @Override
+    protected void validate(BindingResult errors, @Nullable Node updateEntity) throws ValidationException {
+        // nothing to validate
+    }
+
+    /**
+     * Validates RPC (mandatory attributes, correct object state etc.).
+     *
+     * @param errors       Binding/validation errors
+     * @param updateEntity {@code null} if new entity is created otherwise entity that is updated
+     * @throws ValidationException when there is error in input data
+     */
+    public final void preSaveValidation(BindingResult errors, @Nullable Node updateEntity) throws ValidationException {
+        validate(errors, updateEntity);
+    }
+
+    @Override
+    protected MutableNode createEntityInstance(Map<String, ?> params) {
+        throw new UnsupportedOperationException("Node entity can be updated only, not created");
+    }
+
+    @Override
+    protected void updateAttributes(Node param, boolean created) {
+        throw new UnsupportedOperationException("Node entity can be updated only via MutableNode");
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        Assert.hasText(name, "Name must not be empty");
+        this.name = name;
+    }
+
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        Assert.hasText(state, "State must not be empty");
+        this.state = state;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("id", id)
+                .append("code", code)
+                .append("name", name)
+                .append("description", description)
+                .append("state", state)
+                .toString();
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/CollectionWrapper.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/CollectionWrapper.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.common.rpc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.Assert;
+
+
+/**
+ * Collection wrapper of items.
+ *
+ * @param <T> - type of item in collection result
+ * @author Tomas Hanus
+ * @since 2.0
+ */
+public class CollectionWrapper<T> {
+
+    private final List<T> data;
+
+    /**
+     * Constructor of {@code CollectionJson}.
+     *
+     * @param data the content, must not be {@literal null}.
+     */
+    public CollectionWrapper(List<T> data) {
+        Assert.notNull(data, "Data must not be null");
+        this.data = data;
+    }
+
+    /**
+     * Constructor of {@code CollectionJson}.
+     *
+     * @param data the content, must not be {@literal null}.
+     */
+    public <S> CollectionWrapper(Converter<? super S, ? extends T> converter, List<S> data) {
+        Assert.notNull(converter, "Converter must not be null");
+        Assert.notNull(data, "Data must not be null");
+
+        List<T> result = new ArrayList<>();
+
+        for (S element : data) {
+            result.add(converter.convert(element));
+        }
+
+        this.data = result;
+    }
+
+    /**
+     * Gets the content.
+     *
+     * @return collection of items
+     */
+    public List<T> getData() {
+        return data;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("data", data)
+                .toString();
+    }
+}

--- a/web-admin/src/test/java/org/openhubframework/openhub/admin/web/cluster/node/rest/ClusterNodeControllerTest.java
+++ b/web-admin/src/test/java/org/openhubframework/openhub/admin/web/cluster/node/rest/ClusterNodeControllerTest.java
@@ -1,0 +1,191 @@
+/*
+ *  Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.cluster.node.rest;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.text.IsEmptyString.isEmptyString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import static org.openhubframework.openhub.test.rest.TestRestUtils.createGetUrl;
+import static org.openhubframework.openhub.test.rest.TestRestUtils.createJson;
+import static org.openhubframework.openhub.test.rest.TestRestUtils.toUrl;
+
+import javax.json.JsonObject;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.transaction.annotation.Transactional;
+
+import org.openhubframework.openhub.admin.AbstractAdminModuleRestTest;
+import org.openhubframework.openhub.api.entity.MutableNode;
+import org.openhubframework.openhub.api.entity.Node;
+import org.openhubframework.openhub.api.entity.NodeState;
+import org.openhubframework.openhub.api.exception.NoDataFoundException;
+import org.openhubframework.openhub.spi.node.NodeService;
+
+
+/**
+ * Test suite that verifies {@link ClusterNodeController} (REST API).
+ *
+ * @author Tomas Hanus
+ * @since 2.0
+ */
+@Transactional
+public class ClusterNodeControllerTest extends AbstractAdminModuleRestTest {
+
+    private static final String ROOT_URI = ClusterNodeController.REST_URI;
+
+    private Node firstNode;
+    private Node secondNode;
+
+    @Autowired
+    private NodeService nodeService;
+
+    @Before
+    public void prepareData() {
+        firstNode = new MutableNode("codeFirst", "nameFirst");
+        secondNode = new MutableNode("codeSecond", "nameSecond", NodeState.STOPPED);
+        ((MutableNode) secondNode).setDescription("descriptionSecond");
+
+        firstNode = nodeService.insert(firstNode);
+        secondNode = nodeService.insert(secondNode);
+    }
+
+    @Test
+    public void findAll() throws Exception {
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI);
+
+        // performs GET: /api/cluster/nodes
+        mockMvc.perform(get(toUrl(uriBuilder))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("data[0].id", equalTo(firstNode.getId().intValue())))
+                .andExpect(jsonPath("data[0].code", is(firstNode.getCode())))
+                .andExpect(jsonPath("data[0].name", is(firstNode.getName())))
+                .andExpect(jsonPath("data[0].description").doesNotExist())
+                .andExpect(jsonPath("data[0].state", is(firstNode.getState().name())))
+                .andExpect(jsonPath("data[1].id", equalTo(secondNode.getId().intValue())))
+                .andExpect(jsonPath("data[1].code", is(secondNode.getCode())))
+                .andExpect(jsonPath("data[1].name", is(secondNode.getName())))
+                .andExpect(jsonPath("data[1].description", is(secondNode.getDescription())))
+                .andExpect(jsonPath("data[1].state", is(secondNode.getState().name())));
+    }
+
+    @Test
+    public void testGetById() throws Exception {
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI + "/" + firstNode.getId());
+
+        // performs GET: /api/cluster/nodes/1
+        mockMvc.perform(get(toUrl(uriBuilder))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("id", equalTo(firstNode.getId().intValue())))
+                .andExpect(jsonPath("code", is(firstNode.getCode())))
+                .andExpect(jsonPath("name", is(firstNode.getName())))
+                .andExpect(jsonPath("description").doesNotExist())
+                .andExpect(jsonPath("state", is(firstNode.getState().name())));
+    }
+
+    @Test
+    public void testUpdate() throws Exception {
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI + "/" + firstNode.getId());
+
+        JsonObject request = createJson()
+                .add("name", "updatedFirstNode")
+                .add("description", "updated")
+                .add("state", "STOPPED")
+                .build();
+
+        // performs PUT: /api/cluster/nodes/1
+        mockMvc.perform(put(toUrl(uriBuilder))
+                .content(request.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isNoContent())
+                .andExpect(content().string(isEmptyString()));
+
+        // check updated property
+        Node tested = nodeService.getNodeById(firstNode.getId());
+        assertThat(tested.getName(), is("updatedFirstNode"));
+        assertThat(tested.getDescription(), is("updated"));
+        assertThat(tested.getState(), is(NodeState.STOPPED));
+    }
+
+    @Test
+    public void testUpdate_error() throws Exception {
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI + "/" + firstNode.getId());
+
+        JsonObject request = createJson()
+                .add("name", "updatedFirstNode")
+                .add("description", "updated")
+                .build();
+
+        // performs PUT: /api/cluster/nodes/1
+        mockMvc.perform(put(toUrl(uriBuilder))
+                .content(request.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("errorCode", is("E109")))
+                .andExpect(jsonPath("type", is("InputValidationException")))
+                .andExpect(jsonPath("message",
+                        Matchers.is("Input validation error in object 'nodeRpc'")))
+                .andExpect(jsonPath("httpStatus", is(400)))
+                .andExpect(jsonPath("inputFields[0].objectName", is("nodeRpc")))
+                .andExpect(jsonPath("inputFields[0].field", is("state")))
+                .andExpect(jsonPath("inputFields[0].code", is("NotEmpty")))
+                .andExpect(jsonPath("inputFields[0].message", is("may not be empty")))                
+                .andExpect(jsonPath("httpDesc", is("Bad Request")));
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI + "/" + firstNode.getId());
+
+        // performs PUT: /api/cluster/nodes/1
+        mockMvc.perform(delete(toUrl(uriBuilder))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isNoContent());
+
+        try {
+            nodeService.getNodeById(firstNode.getNodeId());
+            fail("Node cannot not exist");
+        } catch (Exception e) {
+            assertThat(e, instanceOf(NoDataFoundException.class));
+        }
+    }
+}


### PR DESCRIPTION
Exposed endpoint for management cluster node entities via REST calls.

API design: http://docs.openhubframework.apiary.io/#reference/0/openhub-cluster-nodes-management
Mockup design: https://openwise.mybalsamiq.com/projects/openhub/Cluster%20nodes

## Changes

- fixed javadoc for `NodeService` API
- added implementation via `ClusterNodeController`
- added test to verify functionality
- added `CollectionWrapper` class to hold RPC items

Issue: OHFJIRA-51