### PR TITLE
Fixed problem with serialization REST objects into XML format.

### DIFF
--- a/web-admin/pom.xml
+++ b/web-admin/pom.xml
@@ -77,7 +77,11 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
-
+        <!-- XML support-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+        </dependency>
 
         <!-- Spring security JSP tags -->
         <dependency>

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/auth/rpc/AuthInfoRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/auth/rpc/AuthInfoRpc.java
@@ -20,7 +20,6 @@ import java.security.Principal;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -35,7 +34,6 @@ import org.springframework.security.core.Authentication;
  * @author Tomas Hanus
  * @since 2.0
  */
-@XmlRootElement
 public class AuthInfoRpc {
 
     private final String fullName;

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/auth/rpc/RoleInfoRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/auth/rpc/RoleInfoRpc.java
@@ -16,8 +16,6 @@
 
 package org.openhubframework.openhub.admin.web.auth.rpc;
 
-import javax.xml.bind.annotation.XmlRootElement;
-
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -30,7 +28,6 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  * @author Tomas Hanus
  * @since 2.0
  */
-@XmlRootElement
 public class RoleInfoRpc {
 
     private final String name;

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/cluster/node/rpc/NodeRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/cluster/node/rpc/NodeRpc.java
@@ -20,7 +20,6 @@ import static org.springframework.util.StringUtils.hasText;
 
 import java.util.Map;
 import javax.annotation.Nullable;
-import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -46,7 +45,6 @@ import org.openhubframework.openhub.spi.node.ChangeNodeCallback;
  * @author Tomas Hanus
  * @since 2.0
  */
-@XmlRootElement
 @Validated
 public class NodeRpc extends ChangeableRpc<Node, Long> {
 

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/BaseRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/common/rpc/BaseRpc.java
@@ -18,7 +18,6 @@ package org.openhubframework.openhub.admin.web.common.rpc;
 
 import java.io.Serializable;
 import javax.annotation.Nullable;
-import javax.xml.bind.annotation.XmlAttribute;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -65,7 +64,6 @@ public abstract class BaseRpc<T extends Identifiable<ID>, ID extends Serializabl
 
     @Nullable
     @Override
-    @XmlAttribute
     public ID getId() {
         return id;
     }

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/configuration/rpc/DbConfigurationParamRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/configuration/rpc/DbConfigurationParamRpc.java
@@ -19,7 +19,6 @@ package org.openhubframework.openhub.admin.web.configuration.rpc;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
-import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -41,7 +40,6 @@ import org.openhubframework.openhub.api.exception.validation.ValidationException
  * @author Petr Juza
  * @since 2.0
  */
-@XmlRootElement
 @Validated
 public class DbConfigurationParamRpc extends ChangeableRpc<DbConfigurationParam, String> {
 

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rpc/ErrorCodeRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rpc/ErrorCodeRpc.java
@@ -16,16 +16,16 @@
 
 package org.openhubframework.openhub.admin.web.errorscatalog.rpc;
 
-import javax.xml.bind.annotation.XmlRootElement;
-
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 
 /**
+ * RPC object to hold error code.
+ * 
  * @author Tomas Hanus
+ * @see 2.0
  */
-@XmlRootElement
 public class ErrorCodeRpc {
     
     private final String code;

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rpc/ErrorsCatalogRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/errorscatalog/rpc/ErrorsCatalogRpc.java
@@ -18,16 +18,17 @@ package org.openhubframework.openhub.admin.web.errorscatalog.rpc;
 
 import java.util.Collections;
 import java.util.List;
-import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 
 /**
+ * RPC object that holds error catalog.
+ * 
  * @author Tomas Hanus
+ * @see 2.0
  */
-@XmlRootElement
 public class ErrorsCatalogRpc {
 
     private final String name;

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/services/wsdl/rpc/WsdlInfoRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/services/wsdl/rpc/WsdlInfoRpc.java
@@ -16,8 +16,6 @@
 
 package org.openhubframework.openhub.admin.web.services.wsdl.rpc;
 
-import javax.xml.bind.annotation.XmlRootElement;
-
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -27,7 +25,6 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  *
  * @author Karel Kovarik
  */
-@XmlRootElement
 public class WsdlInfoRpc {
 
     private final String name;


### PR DESCRIPTION
To whole support of XML serialization it is necessary to include [jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml) dependency otherwise there is for example problem with Serializable interface (BaseRpc).

See [How to create a SpringBoot XML REST Service](http://javasampleapproach.com/spring-framework/spring-boot/create-springboot-xml-rest-service)

Issue: NOISSUE