### PR TITLE
Fixed problem with Spring Boot actuator for multiple web applications

### DIFF
--- a/web-admin/src/main/resources/application.properties
+++ b/web-admin/src/main/resources/application.properties
@@ -134,6 +134,10 @@ spring.jackson.serialization.WRITE_DATES_AS_TIMESTAMPS = false
 # = ACTUATOR PROPERTIES
 # ===============================
 
+# JMX domain customization
+endpoints.jmx.domain=${info.app.name}
+endpoints.jmx.unique-names=true
+
 # Enable Jolokia endpoint.
 endpoints.jolokia.enabled=true
 # Endpoint URL path.


### PR DESCRIPTION
This situation throws javax.management.InstanceAlreadyExistsException exception.

```java
org.springframework.jmx.export.UnableToRegisterMBeanException: Unable to register MBean [org.springframework.boot.actuate.endpoint.jmx.DataEndpointMBean@14bee2f1] with key 'metricsEndpoint'; nested exception is javax.management.InstanceAlreadyExistsException: org.springframework.boot:type=Endpoint,name=metricsEndpoint
        at org.springframework.jmx.export.MBeanExporter.registerBeanNameOrInstance(MBeanExporter.java:609)
        at org.springframework.boot.actuate.endpoint.jmx.EndpointMBeanExporter.registerEndpoint(EndpointMBeanExporter.java:162)
        at org.springframework.boot.actuate.endpoint.jmx.EndpointMBeanExporter.locateAndRegisterEndpoints(EndpointMBeanExporter.java:142)
        at org.springframework.boot.actuate.endpoint.jmx.EndpointMBeanExporter.doStart(EndpointMBeanExporter.java:134)
        at org.springframework.boot.actuate.endpoint.jmx.EndpointMBeanExporter.start(EndpointMBeanExporter.java:257)
        at org.springframework.context.support.DefaultLifecycleProcessor.doStart(DefaultLifecycleProcessor.java:173)
        at org.springframework.context.support.DefaultLifecycleProcessor.access$200(DefaultLifecycleProcessor.java:51)
        at org.springframework.context.support.DefaultLifecycleProcessor$LifecycleGroup.start(DefaultLifecycleProcessor.java:346)
        at org.springframework.context.support.DefaultLifecycleProcessor.startBeans(DefaultLifecycleProcessor.java:149)
        at org.springframework.context.support.DefaultLifecycleProcessor.onRefresh(DefaultLifecycleProcessor.java:112)
        at org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:775)
        at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.finishRefresh(EmbeddedWebApplicationContext.java:131)
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:485)
        at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.refresh(EmbeddedWebApplicationContext.java:109)
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:691)
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:320)
        at org.springframework.boot.builder.SpringApplicationBuilder.run(SpringApplicationBuilder.java:142)
```

If application contains more than one Spring ApplicationContext it throws names clash. To solve this problem it is necessary to set the endpoints.jmx.unique-names property to true so that MBean names are always unique.

See [Spring Boot documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-jmx.html#production-ready-custom-mbean-names).
Issue: NOISSUE