### PR TITLE
OHFJIRA-45 - Stop processing synchronous requests in stopping mode

### DIFF
--- a/core-api/src/main/java/org/openhubframework/openhub/api/configuration/CoreProps.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/configuration/CoreProps.java
@@ -152,6 +152,11 @@ public class CoreProps {
      */
     public static final String CLUSTER_ACTUAL_NODE_INSTANCE_CODE = PREFIX + "cluster.actualNodeInstance.code";
 
+    /**
+     * Pattern for all input URIs into ESB.
+     */
+    public static final String URI_INPUT_PATTERN_FILTER = PREFIX + "uri.inputPattern";
+
     private CoreProps() {
     }
 }

--- a/core-api/src/main/java/org/openhubframework/openhub/api/route/AbstractBasicRoute.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/route/AbstractBasicRoute.java
@@ -20,10 +20,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import javax.xml.namespace.QName;
 
-import org.apache.camel.Exchange;
-import org.apache.camel.Handler;
-import org.apache.camel.Header;
-import org.apache.camel.LoggingLevel;
+import org.apache.camel.*;
 import org.apache.camel.processor.DefaultExchangeFormatter;
 import org.apache.camel.spi.EventNotifier;
 import org.apache.camel.spring.SpringRouteBuilder;
@@ -38,11 +35,7 @@ import org.springframework.util.Assert;
 import org.openhubframework.openhub.api.asynch.AsynchConstants;
 import org.openhubframework.openhub.api.entity.ExternalSystemExtEnum;
 import org.openhubframework.openhub.api.entity.ServiceExtEnum;
-import org.openhubframework.openhub.api.exception.BusinessException;
-import org.openhubframework.openhub.api.exception.LockFailureException;
-import org.openhubframework.openhub.api.exception.MultipleDataFoundException;
-import org.openhubframework.openhub.api.exception.NoDataFoundException;
-import org.openhubframework.openhub.api.exception.validation.ValidationException;
+import org.openhubframework.openhub.api.exception.*;
 
 
 /**
@@ -59,6 +52,7 @@ public abstract class AbstractBasicRoute extends SpringRouteBuilder {
      */
     public static final String ROUTE_SUFFIX = "_route";
 
+
     /**
      * Suffix for asynchronous incoming routes.
      */
@@ -73,6 +67,16 @@ public abstract class AbstractBasicRoute extends SpringRouteBuilder {
      * Suffix for outbound routes with external systems.
      */
     public static final String EXTERNAL_ROUTE_SUFFIX = "_external_route";
+
+    /**
+     * Delimiter in generated route id for service and operation name.
+     *
+     * @see #getRouteId(ServiceExtEnum, String)
+     * @see #getInRouteId(ServiceExtEnum, String)
+     * @see #getOutRouteId(ServiceExtEnum, String)
+     * @see #getExternalRouteId(ExternalSystemExtEnum, String)
+     */
+    public static final String ROUTE_ID_DELIMITER = "_";
 
     // note: I prefer using this before calling repeatedly lookup method for getting bean implementation
     @Autowired(required = false)
@@ -279,7 +283,7 @@ public abstract class AbstractBasicRoute extends SpringRouteBuilder {
         Assert.notNull(service, "the service must not be null");
         Assert.hasText(operationName, "the operationName must not be empty");
 
-        return service.getServiceName() + "_" + operationName + ROUTE_SUFFIX;
+        return service.getServiceName() + ROUTE_ID_DELIMITER + operationName + ROUTE_SUFFIX;
     }
 
     /**
@@ -294,7 +298,7 @@ public abstract class AbstractBasicRoute extends SpringRouteBuilder {
         Assert.notNull(service, "the service must not be null");
         Assert.hasText(operationName, "the operationName must not be empty");
 
-        return service.getServiceName() + "_" + operationName + IN_ROUTE_SUFFIX;
+        return service.getServiceName() + ROUTE_ID_DELIMITER + operationName + IN_ROUTE_SUFFIX;
     }
 
     /**
@@ -309,7 +313,7 @@ public abstract class AbstractBasicRoute extends SpringRouteBuilder {
         Assert.notNull(service, "the service must not be null");
         Assert.hasText(operationName, "the operationName must not be empty");
 
-        return service.getServiceName() + "_" + operationName + OUT_ROUTE_SUFFIX;
+        return service.getServiceName() + ROUTE_ID_DELIMITER + operationName + OUT_ROUTE_SUFFIX;
     }
 
     /**
@@ -324,7 +328,7 @@ public abstract class AbstractBasicRoute extends SpringRouteBuilder {
         Assert.notNull(system, "the system must not be null");
         Assert.hasText(operationName, "the operationName must not be empty");
 
-        return system.getSystemName() + "_" + operationName + EXTERNAL_ROUTE_SUFFIX;
+        return system.getSystemName() + ROUTE_ID_DELIMITER + operationName + EXTERNAL_ROUTE_SUFFIX;
     }
 
     /**

--- a/core-api/src/main/java/org/openhubframework/openhub/api/route/RouteType.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/route/RouteType.java
@@ -1,0 +1,20 @@
+package org.openhubframework.openhub.api.route;
+
+/**
+ * Type of route.
+ * To identify new type of route implements {@link RouteTypeResolver}.
+ *
+ * @author Roman Havlicek
+ * @see RouteTypeResolver
+ * @see RouteTypeInfo
+ * @since 2.0
+ */
+public interface RouteType {
+
+    /**
+     * Gets name of route type.
+     *
+     * @return name
+     */
+    String getName();
+}

--- a/core-api/src/main/java/org/openhubframework/openhub/api/route/RouteTypeInfo.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/route/RouteTypeInfo.java
@@ -1,0 +1,142 @@
+package org.openhubframework.openhub.api.route;
+
+import javax.annotation.Nullable;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Route;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+/**
+ * Contains information about route for getting {@link RouteType} in {@link RouteTypeResolver}.
+ *
+ * @author Romah Havlicek
+ * @see RouteType
+ * @see RouteTypeResolver
+ * @since 2.0
+ */
+public class RouteTypeInfo {
+
+    /**
+     * Route.
+     */
+    private final Route route;
+
+    /**
+     * Exchange.
+     */
+    private final Exchange exchange;
+
+    /**
+     * Route id.
+     */
+    private final String routeId;
+
+    /**
+     * Route definition.
+     */
+    private final RouteDefinition routeDefinition;
+
+    /**
+     * New instance.
+     *
+     * @param route           route, {@code NULl} no route object
+     * @param exchange        exchange, {@code NULL} no exchange object
+     * @param routeId         route id, {@code NULL} no route id
+     * @param routeDefinition route definition, {@code NULL} no route definition
+     */
+    public RouteTypeInfo(@Nullable Route route, @Nullable Exchange exchange, @Nullable String routeId,
+                         @Nullable RouteDefinition routeDefinition) {
+        this.route = route;
+        this.exchange = exchange;
+        this.routeId = routeId;
+        this.routeDefinition = routeDefinition;
+    }
+
+    //--------------------------------------------------- SET / GET ----------------------------------------------------
+
+    /**
+     * Gets route.
+     *
+     * @return route, {@code NULL} - no route
+     */
+    @Nullable
+    public Route getRoute() {
+        return route;
+    }
+
+    /**
+     * Gets exchange.
+     *
+     * @return exchange, {@code NULL} - no exchange
+     */
+    @Nullable
+    public Exchange getExchange() {
+        return exchange;
+    }
+
+    /**
+     * Gets route id.
+     *
+     * @return route id, {@code NULL} - no route id
+     */
+    @Nullable
+    public String getRouteId() {
+        return routeId;
+    }
+
+    /**
+     * Gets route definition.
+     *
+     * @return route definition, {@code NULL} route definition
+     */
+    @Nullable
+    public RouteDefinition getRouteDefinition() {
+        return routeDefinition;
+    }
+
+    //--------------------------------------------- TOSTRING / HASH / EQUALS -------------------------------------------
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof RouteTypeInfo)) {
+            return false;
+        }
+
+        RouteTypeInfo that = (RouteTypeInfo) o;
+
+        return new EqualsBuilder()
+                .append(getRoute(), that.getRoute())
+                .append(getExchange(), that.getExchange())
+                .append(getRouteId(), that.getRouteId())
+                .append(getRouteDefinition(), that.getRouteDefinition())
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(getRoute())
+                .append(getExchange())
+                .append(getRouteId())
+                .append(getRouteDefinition())
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("route", route)
+                .append("exchange", exchange)
+                .append("routeId", routeId)
+                .append("routeDefinition", routeDefinition)
+                .toString();
+    }
+}

--- a/core-api/src/main/java/org/openhubframework/openhub/api/route/RouteTypeResolver.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/route/RouteTypeResolver.java
@@ -1,0 +1,23 @@
+package org.openhubframework.openhub.api.route;
+
+import javax.annotation.Nullable;
+
+/**
+ * Resolver for getting {@link RouteType} from {@link RouteTypeInfo}.
+ *
+ * @author Romah Havlicek
+ * @see RouteType
+ * @see RouteTypeInfo
+ * @since 2.0
+ */
+public interface RouteTypeResolver {
+
+    /**
+     * Gets {@link RouteType} from information about route in object {@link RouteTypeInfo}.
+     *
+     * @param routeTypeInfo information about route
+     * @return route type, {@code NULL} route type was not recognized
+     */
+    @Nullable
+    RouteType findRouteType(RouteTypeInfo routeTypeInfo);
+}

--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/route/RouteDefinitionService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/route/RouteDefinitionService.java
@@ -1,0 +1,37 @@
+package org.openhubframework.openhub.spi.route;
+
+import javax.annotation.Nullable;
+
+import org.openhubframework.openhub.api.route.RouteType;
+import org.openhubframework.openhub.api.route.RouteTypeInfo;
+import org.openhubframework.openhub.api.route.RouteTypeResolver;
+
+/**
+ * Service for getting information about route.
+ *
+ * @author Roman Havlicek
+ * @see RouteType
+ * @see RouteTypeInfo
+ * @see RouteTypeResolver
+ * @since 2.0
+ */
+public interface RouteDefinitionService {
+
+    /**
+     * Gets {@link RouteType} from information about route in object {@link RouteTypeInfo}.
+     *
+     * @param routeTypeInfo information about route
+     * @return route type, {@code NULL} route type was not recognized
+     */
+    @Nullable
+    RouteType findRouteType(RouteTypeInfo routeTypeInfo);
+
+    /**
+     * Gets if route is input route.
+     * Input route has input into ESB (Webservice, REST, etc.).
+     *
+     * @param routeTypeInfo infrmation about route
+     * @return {@code true} is input route, {@code false} otherwise
+     */
+    boolean isInputRoute(RouteTypeInfo routeTypeInfo);
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchInMessageRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchInMessageRoute.java
@@ -47,7 +47,6 @@ import org.openhubframework.openhub.core.common.event.AsynchEventHelper;
 import org.openhubframework.openhub.core.common.exception.ExceptionTranslator;
 import org.openhubframework.openhub.core.common.validator.TraceIdentifierValidator;
 import org.openhubframework.openhub.spi.msg.MessageService;
-import org.openhubframework.openhub.spi.node.NodeService;
 import org.openhubframework.openhub.spi.throttling.ThrottleScope;
 import org.openhubframework.openhub.spi.throttling.ThrottlingProcessor;
 
@@ -117,9 +116,6 @@ public class AsynchInMessageRoute extends AbstractBasicRoute {
                 // check headers existence
                 .validate(header(SERVICE_HEADER).isNotNull())
                 .validate(header(OPERATION_HEADER).isNotNull())
-
-                // check if ESB is not stopping?
-                .bean(ROUTE_BEAN, "checkStopping").id("stopChecking")
 
                 // extract trace header, trace header is mandatory
                 .process(new TraceHeaderProcessor(true, validatorList))
@@ -308,18 +304,6 @@ public class AsynchInMessageRoute extends AbstractBasicRoute {
 
         // generates event
         AsynchEventHelper.notifyMsgPostponed(exchange);
-    }
-
-    /**
-     * Checks if ESB goes down or not. If yes then {@link StoppingException} is thrown.
-     */
-    @Handler
-    public void checkStopping() {
-        NodeService nodeService = getApplicationContext().getBean(NodeService.class);
-
-        if (!nodeService.getActualNode().isAbleToHandleNewMessages()) {
-            throw new StoppingException("ESB is stopping ...");
-        }
     }
 
     /**

--- a/core/src/main/java/org/openhubframework/openhub/core/common/processingmessage/StartProcessingMessagePolicy.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/processingmessage/StartProcessingMessagePolicy.java
@@ -1,0 +1,53 @@
+package org.openhubframework.openhub.core.common.processingmessage;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Route;
+import org.apache.camel.support.RoutePolicySupport;
+import org.springframework.util.Assert;
+
+import org.openhubframework.openhub.api.exception.StoppingException;
+import org.openhubframework.openhub.core.common.route.RouteTypeEnum;
+import org.openhubframework.openhub.spi.node.NodeService;
+import org.openhubframework.openhub.spi.route.RouteDefinitionService;
+import org.openhubframework.openhub.api.route.RouteTypeInfo;
+import org.openhubframework.openhub.api.route.RouteTypeResolver;
+
+/**
+ * Policy that check if ESB is stopped and refused with exception {@link StoppingException} all incoming call.
+ * Input route is recognized by method {@link RouteDefinitionService#isInputRoute(RouteTypeInfo)}.
+ *
+ * @author Roman Havlicek
+ * @see RouteDefinitionService#isInputRoute(RouteTypeInfo)
+ * @see RouteTypeEnum#INPUT
+ * @see RouteTypeResolver
+ * @see StartProcessingMessagePolicyFactory
+ * @since 2.0
+ */
+public class StartProcessingMessagePolicy extends RoutePolicySupport {
+
+    /**
+     * Service for check if ESB is stopped.
+     */
+    private final NodeService nodeService;
+
+    /**
+     * New instance.
+     *
+     * @param nodeService node service
+     */
+    public StartProcessingMessagePolicy(NodeService nodeService) {
+        Assert.notNull(nodeService, "nodeService must not be null");
+
+        this.nodeService = nodeService;
+    }
+
+    @Override
+    public void onExchangeBegin(Route route, Exchange exchange) {
+        Assert.notNull(route, "route must not be null");
+        Assert.notNull(exchange, "exchange must not be null");
+
+        if (!nodeService.getActualNode().isAbleToHandleNewMessages()) {
+            exchange.setException(new StoppingException("ESB is stopping ..."));
+        }
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/common/processingmessage/StartProcessingMessagePolicyFactory.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/processingmessage/StartProcessingMessagePolicyFactory.java
@@ -1,0 +1,67 @@
+package org.openhubframework.openhub.core.common.processingmessage;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.camel.spi.RoutePolicy;
+import org.apache.camel.spi.RoutePolicyFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import org.openhubframework.openhub.core.common.route.RouteTypeEnum;
+import org.openhubframework.openhub.spi.node.NodeService;
+import org.openhubframework.openhub.spi.route.RouteDefinitionService;
+import org.openhubframework.openhub.api.route.RouteTypeInfo;
+import org.openhubframework.openhub.api.route.RouteTypeResolver;
+
+/**
+ * Factory for create {@link StartProcessingMessagePolicy} which refused incoming call for input route if ESB is stopped.
+ * Input route is recognized by method {@link RouteDefinitionService#isInputRoute(RouteTypeInfo)}.
+ *
+ * @author Roman Havlicek
+ * @see RouteDefinitionService#isInputRoute(RouteTypeInfo)
+ * @see RouteTypeEnum#INPUT
+ * @see RouteTypeResolver
+ * @see StartProcessingMessagePolicy
+ * @since 2.0
+ */
+@Component
+public class StartProcessingMessagePolicyFactory implements RoutePolicyFactory {
+
+    /**
+     * One instance of {@link StartProcessingMessagePolicy}.
+     * For getting instace use {@link #getStartProcessingMessagePolicy()}.
+     */
+    private StartProcessingMessagePolicy startProcessingMessagePolicy;
+
+    @Autowired
+    private RouteDefinitionService routeDefinitionService;
+
+    @Autowired
+    private NodeService nodeService;
+
+    @Override
+    public RoutePolicy createRoutePolicy(CamelContext camelContext, String routeId, RouteDefinition route) {
+        Assert.notNull(camelContext, "camelContext must not be null");
+        Assert.hasText(routeId, "routeId must not be empty");
+        Assert.notNull(route, "route must not be null");
+
+        if (routeDefinitionService.isInputRoute(new RouteTypeInfo(null, null, routeId, route))) {
+            return getStartProcessingMessagePolicy();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get instance of {@link StartProcessingMessagePolicy}.
+     *
+     * @return instance of {@link StartProcessingMessagePolicy}
+     */
+    private synchronized StartProcessingMessagePolicy getStartProcessingMessagePolicy() {
+        if (startProcessingMessagePolicy == null) {
+            startProcessingMessagePolicy = new StartProcessingMessagePolicy(nodeService);
+        }
+        return startProcessingMessagePolicy;
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/common/route/RouteDefinitionServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/route/RouteDefinitionServiceImpl.java
@@ -1,0 +1,57 @@
+package org.openhubframework.openhub.core.common.route;
+
+import java.util.List;
+import javax.annotation.Nullable;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import org.openhubframework.openhub.api.route.RouteType;
+import org.openhubframework.openhub.spi.route.RouteDefinitionService;
+import org.openhubframework.openhub.api.route.RouteTypeInfo;
+import org.openhubframework.openhub.api.route.RouteTypeResolver;
+
+/**
+ * Default service for getting information about route.
+ *
+ * @author Roman Havlicek
+ * @see RouteTypeResolver
+ * @see RouteType
+ * @see RouteTypeUriResolver
+ * @see RouteTypeInRouteIdResolver
+ * @see RouteTypeInfo
+ * @since 2.0
+ */
+@Service
+public class RouteDefinitionServiceImpl implements RouteDefinitionService {
+
+    @Autowired(required = false)
+    private List<RouteTypeResolver> routeTypeResolvers;
+
+    @Nullable
+    @Override
+    public RouteType findRouteType(RouteTypeInfo routeTypeInfo) {
+        Assert.notNull(routeTypeInfo, "routeTypeInfo must not be null");
+
+        RouteType result = null;
+        if (!CollectionUtils.isEmpty(routeTypeResolvers)) {
+            for (RouteTypeResolver routeTypeResolver : routeTypeResolvers) {
+                result = routeTypeResolver.findRouteType(routeTypeInfo);
+                if (result != null) {
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean isInputRoute(RouteTypeInfo routeTypeInfo) {
+        Assert.notNull(routeTypeInfo, "routeTypeInfo must not be null");
+
+        RouteType routeType = findRouteType(routeTypeInfo);
+        return routeType != null && routeType.getName().equals(RouteTypeEnum.INPUT.getName());
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/common/route/RouteTypeEnum.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/route/RouteTypeEnum.java
@@ -1,0 +1,29 @@
+package org.openhubframework.openhub.core.common.route;
+
+import org.openhubframework.openhub.api.route.RouteType;
+import org.openhubframework.openhub.spi.route.RouteDefinitionService;
+import org.openhubframework.openhub.api.route.RouteTypeInfo;
+import org.openhubframework.openhub.api.route.RouteTypeResolver;
+
+/**
+ * Contains all base route types.
+ *
+ * @author Roman Havlicek
+ * @see RouteType
+ * @see RouteTypeResolver
+ * @see RouteDefinitionService
+ * @see RouteTypeInfo
+ * @since 2.0
+ */
+public enum RouteTypeEnum implements RouteType {
+
+    /**
+     * Route of this type is input route into ESB (web service, REST etc.).
+     */
+    INPUT;
+
+    @Override
+    public String getName() {
+        return name();
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/common/route/RouteTypeInRouteIdResolver.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/route/RouteTypeInRouteIdResolver.java
@@ -1,0 +1,64 @@
+package org.openhubframework.openhub.core.common.route;
+
+import javax.annotation.Nullable;
+
+import org.apache.camel.model.RouteDefinition;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import org.openhubframework.openhub.api.route.RouteType;
+import org.openhubframework.openhub.api.entity.ServiceExtEnum;
+import org.openhubframework.openhub.api.route.AbstractBasicRoute;
+import org.openhubframework.openhub.spi.route.RouteDefinitionService;
+import org.openhubframework.openhub.api.route.RouteTypeInfo;
+import org.openhubframework.openhub.api.route.RouteTypeResolver;
+
+/**
+ * Resolver for getting {@link RouteType} by route input route identifier ({@link RouteDefinition#routeId(String)}).
+ *
+ * @author Roman Havlicek
+ * @see RouteDefinition#routeId(String)
+ * @see RouteTypeEnum
+ * @see RouteType
+ * @see RouteDefinitionService
+ * @see RouteTypeInfo
+ * @since 2.0
+ */
+@Component
+@Order(RouteTypeInRouteIdResolver.ORDER)
+public class RouteTypeInRouteIdResolver implements RouteTypeResolver {
+
+    public static final int ORDER = RouteTypeUriResolver.ORDER + 1;
+
+    /**
+     * Regular expression for check input route id ({@link AbstractBasicRoute#getInRouteId(ServiceExtEnum, String)}).
+     */
+    private static final String ROUTE_ID_IN_REG_EXP = ".+" + AbstractBasicRoute.ROUTE_ID_DELIMITER
+            + ".+" + AbstractBasicRoute.IN_ROUTE_SUFFIX + ".*";
+
+    @Nullable
+    @Override
+    public RouteType findRouteType(RouteTypeInfo routeTypeInfo) {
+        Assert.notNull(routeTypeInfo, "routeTypeInfo must not be null");
+
+        String routeId = routeTypeInfo.getRouteId();
+
+        //check in routeDefinition
+        if (StringUtils.isBlank(routeId) && routeTypeInfo.getRouteDefinition() != null) {
+            routeId = routeTypeInfo.getRouteDefinition().getId();
+        }
+
+        //check in route
+        if (StringUtils.isBlank(routeId) && routeTypeInfo.getRoute() != null) {
+            routeId = routeTypeInfo.getRoute().getId();
+        }
+
+        RouteType result = null;
+        if (!StringUtils.isBlank(routeId) && routeId.matches(ROUTE_ID_IN_REG_EXP)) {
+            result = RouteTypeEnum.INPUT;
+        }
+        return result;
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/common/route/RouteTypeUriResolver.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/route/RouteTypeUriResolver.java
@@ -1,0 +1,74 @@
+package org.openhubframework.openhub.core.common.route;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+import org.apache.camel.Route;
+import org.apache.camel.model.FromDefinition;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import org.openhubframework.openhub.api.configuration.ConfigurableValue;
+import org.openhubframework.openhub.api.configuration.ConfigurationItem;
+import org.openhubframework.openhub.api.configuration.CoreProps;
+import org.openhubframework.openhub.api.route.RouteType;
+import org.openhubframework.openhub.spi.route.RouteDefinitionService;
+import org.openhubframework.openhub.api.route.RouteTypeInfo;
+import org.openhubframework.openhub.api.route.RouteTypeResolver;
+
+/**
+ * Resolver for getting {@link RouteType} by route input URI ({@link RouteDefinition#from(String)}).
+ *
+ * @author Roman Havlicek
+ * @see RouteDefinition#from(String)
+ * @see RouteTypeEnum
+ * @see RouteType
+ * @see RouteDefinitionService
+ * @see RouteTypeInfo
+ * @since 2.0
+ */
+@Component
+@Order(RouteTypeUriResolver.ORDER)
+public class RouteTypeUriResolver implements RouteTypeResolver {
+
+    public static final int ORDER = 1;
+
+    @ConfigurableValue(key = CoreProps.URI_INPUT_PATTERN_FILTER)
+    private ConfigurationItem<String> inputUriPattern;
+
+    @Nullable
+    @Override
+    public RouteType findRouteType(RouteTypeInfo routeTypeInfo) {
+        Assert.notNull(routeTypeInfo, "routeTypeInfo must not be null");
+
+        Set<String> uris = new HashSet<>();
+
+        //check uri from route
+        Route route = routeTypeInfo.getRoute();
+        if (route != null && route.getConsumer() != null && route.getConsumer().getEndpoint() != null) {
+            uris.add(routeTypeInfo.getRoute().getConsumer().getEndpoint().getEndpointUri());
+        }
+
+        //check uri from route definition
+        if (routeTypeInfo.getRouteDefinition() != null) {
+            for (FromDefinition fromDefinition : routeTypeInfo.getRouteDefinition().getInputs()) {
+                if (!StringUtils.isBlank(fromDefinition.getUri())) {
+                    uris.add(fromDefinition.getUri());
+                }
+            }
+        }
+
+        RouteType result = null;
+        for (String uri : uris) {
+            if (!StringUtils.isBlank(uri) && uri.matches(inputUriPattern.getValue())) {
+                result = RouteTypeEnum.INPUT;
+                break;
+            }
+        }
+        return result;
+    }
+}

--- a/core/src/main/resources/config/application-test-default.properties
+++ b/core/src/main/resources/config/application-test-default.properties
@@ -87,3 +87,6 @@ ohf.alerts.repeatTimeSec = -1
 
 # pattern for filtering property names which should be loaded from DB
 ohf.dbProperty.includePattern=^ohf\\..*$
+
+# pattern for all input URIs into ESB
+ohf.uri.inputPattern = ^(spring-ws).*$

--- a/core/src/main/resources/db/migration/h2/V1_0_3__new_property.sql
+++ b/core/src/main/resources/db/migration/h2/V1_0_3__new_property.sql
@@ -1,0 +1,4 @@
+-- pattern for all input URIs into ESB
+INSERT INTO configuration_item (code, description, category_code, current_value, default_value, data_type, mandatory, validation)
+    VALUES('ohf.uri.inputPattern', 'Pattern for all input URIs into ESB',
+'core.server', '^(spring-ws).*$', '^(spring-ws).*$', 'STRING', true, null);

--- a/core/src/main/resources/db/migration/postgresql/V1_0_2__new_property.sql
+++ b/core/src/main/resources/db/migration/postgresql/V1_0_2__new_property.sql
@@ -1,0 +1,4 @@
+-- pattern for all input URIs into ESB
+INSERT INTO configuration_item (code, description, category_code, current_value, default_value, data_type, mandatory, validation)
+    VALUES('ohf.uri.inputPattern', 'Pattern for all input URIs into ESB',
+'core.server', '^(spring-ws).*$', '^(spring-ws).*$', 'STRING', true, null);

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRouteTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRouteTest.java
@@ -375,7 +375,7 @@ public class AsynchMessageRouteTest extends AbstractCoreDbTest {
         // verify message
         Message msgDB = em.find(Message.class, msg.getMsgId());
         assertThat(msgDB, notNullValue());
-        assertThat(msgDB.getState(), is(MsgStateEnum.FAILED));
+        assertThat(msgDB.getState(), is(MsgStateEnum.PARTLY_FAILED));
         assertThat(msgDB.getNodeId(), is(nodeService.getActualNode().getNodeId()));
         assertErrorCode(msgDB.getFailedErrorCode(), InternalErrorEnum.E102);
         assertThat(msgDB.getFailedDesc(), notNullValue());

--- a/core/src/test/java/org/openhubframework/openhub/core/common/processingmessage/StartProcessingMessagePolicyFactoryTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/processingmessage/StartProcessingMessagePolicyFactoryTest.java
@@ -1,0 +1,130 @@
+package org.openhubframework.openhub.core.common.processingmessage;
+
+import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.openhubframework.openhub.api.configuration.CoreProps.URI_INPUT_PATTERN_FILTER;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import org.openhubframework.openhub.api.entity.MutableNode;
+import org.openhubframework.openhub.api.exception.IntegrationException;
+import org.openhubframework.openhub.api.route.AbstractBasicRoute;
+import org.openhubframework.openhub.core.AbstractCoreDbTest;
+import org.openhubframework.openhub.core.AbstractCoreTest;
+import org.openhubframework.openhub.core.common.asynch.ExceptionTranslationRoute;
+import org.openhubframework.openhub.spi.node.ChangeNodeCallback;
+import org.openhubframework.openhub.spi.node.NodeService;
+import org.openhubframework.openhub.test.data.ExternalSystemTestEnum;
+import org.openhubframework.openhub.test.data.ServiceTestEnum;
+import org.openhubframework.openhub.test.route.ActiveRoutes;
+
+/**
+ * Test for {@link StartProcessingMessagePolicyFactory}.
+ *
+ * @author Roman Havlicek
+ * @see StartProcessingMessagePolicyFactory
+ * @since 2.0
+ */
+@ActiveRoutes(classes = ExceptionTranslationRoute.class)
+@TestPropertySource(properties = {URI_INPUT_PATTERN_FILTER + "=direct:inputUri"})
+public class StartProcessingMessagePolicyFactoryTest extends AbstractCoreDbTest {
+
+    @EndpointInject(uri = "mock:inputRoute")
+    private MockEndpoint inputRouteMock;
+
+    @EndpointInject(uri = "mock:inputUri")
+    private MockEndpoint inputUriMock;
+
+    @EndpointInject(uri = "mock:outputRoute")
+    private MockEndpoint outputRouteMock;
+
+    @Produce
+    private ProducerTemplate producer;
+
+    @Autowired
+    private NodeService nodeService;
+
+    /**
+     * Init routes for test.
+     *
+     * @throws Exception all errors
+     */
+    @Before
+    public void init() throws Exception {
+        getCamelContext().addRoutes(new AbstractBasicRoute() {
+            @Override
+            protected void doConfigure() throws Exception {
+                from("direct:inputRoute")
+                        .routeId(getInRouteId(ServiceTestEnum.ACCOUNT, "input"))
+                        .to(inputRouteMock);
+
+                from("direct:inputUri")
+                        .routeId(getRouteId(ServiceTestEnum.CUSTOMER, "create"))
+                        .to(inputUriMock);
+
+                from("direct:outputRoute")
+                        .routeId(getExternalRouteId(ExternalSystemTestEnum.BILLING, "output"))
+                        .to(outputRouteMock);
+            }
+        });
+    }
+
+    /**
+     * Test when actual node is running.
+     *
+     * @throws Exception all errors
+     */
+    @Test
+    public void testNodeRun() throws Exception {
+        inputRouteMock.setExpectedMessageCount(1);
+        inputUriMock.setExpectedMessageCount(1);
+        outputRouteMock.setExpectedMessageCount(1);
+
+        producer.sendBody("direct:inputRoute", "Body");
+        producer.sendBody("direct:inputUri", "Body");
+        producer.sendBody("direct:outputRoute", "Body");
+
+        assertIsSatisfied(inputRouteMock, inputUriMock, outputRouteMock);
+    }
+
+    /**
+     * Test when actual node is stopped.
+     *
+     * @throws Exception all errors
+     */
+    @Test
+    public void testNodeStop() throws Exception {
+        nodeService.update(nodeService.getActualNode(), new ChangeNodeCallback() {
+            @Override
+            public void updateNode(MutableNode node) {
+                node.setStoppedState();
+            }
+        });
+
+        inputRouteMock.setExpectedMessageCount(0);
+        inputUriMock.setExpectedMessageCount(0);
+        outputRouteMock.setExpectedMessageCount(1);
+
+        try {
+            producer.sendBody("direct:inputRoute", "Body");
+        } catch (Exception e) {
+            assertThat(e.getCause(), instanceOf(IntegrationException.class));
+        }
+        try {
+            producer.sendBody("direct:inputUri", "Body");
+        } catch (Exception e) {
+            assertThat(e.getCause(), instanceOf(IntegrationException.class));
+        }
+        producer.sendBody("direct:outputRoute", "Body");
+
+        assertIsSatisfied(inputRouteMock, inputUriMock, outputRouteMock);
+    }
+}

--- a/core/src/test/java/org/openhubframework/openhub/core/common/route/RouteDefinitionServiceImplTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/route/RouteDefinitionServiceImplTest.java
@@ -1,0 +1,128 @@
+package org.openhubframework.openhub.core.common.route;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.openhubframework.openhub.api.configuration.CoreProps.URI_INPUT_PATTERN_FILTER;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import org.openhubframework.openhub.api.route.AbstractBasicRoute;
+import org.openhubframework.openhub.api.route.RouteTypeInfo;
+import org.openhubframework.openhub.core.AbstractCoreTest;
+import org.openhubframework.openhub.test.data.ExternalSystemTestEnum;
+import org.openhubframework.openhub.test.data.ServiceTestEnum;
+
+/**
+ * Test for {@link RouteDefinitionServiceImpl}.
+ *
+ * @author Roman Havlicek
+ * @see RouteDefinitionServiceImpl
+ * @since 2.0
+ */
+@TestPropertySource(properties = {URI_INPUT_PATTERN_FILTER + "=direct:.*input.*"})
+public class RouteDefinitionServiceImplTest extends AbstractCoreTest {
+
+    @Autowired
+    private RouteDefinitionServiceImpl routeDefinitionService;
+
+    /**
+     * Init routes for test.
+     *
+     * @throws Exception all errors
+     */
+    @Before
+    public void init() throws Exception {
+        getCamelContext().addRoutes(new AbstractBasicRoute() {
+            @Override
+            protected void doConfigure() throws Exception {
+                from("direct:inputRoute")
+                        .routeId("inputTestRouteOne")
+                        .log("TestRoute");
+
+                from("direct:inputUri")
+                        .routeId("inputTestRouteTwo")
+                        .log("TestRoute");
+
+                from("direct:outputRoute")
+                        .routeId("outputTestRouteOne")
+                        .log("TestRoute");
+            }
+        });
+    }
+
+    /**
+     * Test method {@link RouteDefinitionServiceImpl#findRouteType(RouteTypeInfo)}.
+     *
+     * @throws Exception all errors
+     */
+    @Test
+    public void testFindRouteType() throws Exception {
+        assertThat(routeDefinitionService.findRouteType(
+                        new RouteTypeInfo(getCamelContext().getRoute("inputTestRouteOne"), null, null, null)),
+                is(RouteTypeEnum.INPUT));
+        assertThat(routeDefinitionService.findRouteType(
+                        new RouteTypeInfo(getCamelContext().getRoute("inputTestRouteTwo"), null, null, null)),
+                is(RouteTypeEnum.INPUT));
+        assertThat(routeDefinitionService.findRouteType(
+                        new RouteTypeInfo(getCamelContext().getRoute("outputTestRouteOne"), null, null, null)),
+                nullValue());
+
+        assertThat(routeDefinitionService.findRouteType(new RouteTypeInfo(null, null, null,
+                getCamelContext().getRouteDefinition("inputTestRouteOne"))), is(RouteTypeEnum.INPUT));
+        assertThat(routeDefinitionService.findRouteType(new RouteTypeInfo(null, null, null,
+                getCamelContext().getRouteDefinition("inputTestRouteTwo"))), is(RouteTypeEnum.INPUT));
+        assertThat(routeDefinitionService.findRouteType(new RouteTypeInfo(null, null, null,
+                getCamelContext().getRouteDefinition("outputTestRouteOne"))), nullValue());
+
+        assertThat(routeDefinitionService.findRouteType(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getRouteId(ServiceTestEnum.CUSTOMER, "operation"), null)), nullValue());
+        assertThat(routeDefinitionService.findRouteType(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getExternalRouteId(ExternalSystemTestEnum.CRM, "operation"), null)), nullValue());
+        assertThat(routeDefinitionService.findRouteType(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getOutRouteId(ServiceTestEnum.ACCOUNT, "operation"), null)), nullValue());
+        assertThat(routeDefinitionService.findRouteType(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getInRouteId(ServiceTestEnum.ACCOUNT, "operation"), null)), is(RouteTypeEnum.INPUT));
+        assertThat(routeDefinitionService.findRouteType(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getInRouteId(ServiceTestEnum.CUSTOMER, "test"), null)), is(RouteTypeEnum.INPUT));
+    }
+
+    /**
+     * Test method {@link RouteDefinitionServiceImpl#isInputRoute(RouteTypeInfo)}.
+     *
+     * @throws Exception all errors
+     */
+    @Test
+    public void testIsInputRoute() throws Exception {
+        assertThat(routeDefinitionService.isInputRoute(
+                        new RouteTypeInfo(getCamelContext().getRoute("inputTestRouteOne"), null, null, null)),
+                is(true));
+        assertThat(routeDefinitionService.isInputRoute(
+                        new RouteTypeInfo(getCamelContext().getRoute("inputTestRouteTwo"), null, null, null)),
+                is(true));
+        assertThat(routeDefinitionService.isInputRoute(
+                        new RouteTypeInfo(getCamelContext().getRoute("outputTestRouteOne"), null, null, null)),
+                is(false));
+
+        assertThat(routeDefinitionService.isInputRoute(new RouteTypeInfo(null, null, null,
+                getCamelContext().getRouteDefinition("inputTestRouteOne"))), is(true));
+        assertThat(routeDefinitionService.isInputRoute(new RouteTypeInfo(null, null, null,
+                getCamelContext().getRouteDefinition("inputTestRouteTwo"))), is(true));
+        assertThat(routeDefinitionService.isInputRoute(new RouteTypeInfo(null, null, null,
+                getCamelContext().getRouteDefinition("outputTestRouteOne"))), is(false));
+
+        assertThat(routeDefinitionService.isInputRoute(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getRouteId(ServiceTestEnum.CUSTOMER, "operation"), null)), is(false));
+        assertThat(routeDefinitionService.isInputRoute(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getExternalRouteId(ExternalSystemTestEnum.CRM, "operation"), null)), is(false));
+        assertThat(routeDefinitionService.isInputRoute(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getOutRouteId(ServiceTestEnum.ACCOUNT, "operation"), null)), is(false));
+        assertThat(routeDefinitionService.isInputRoute(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getInRouteId(ServiceTestEnum.ACCOUNT, "operation"), null)), is(true));
+        assertThat(routeDefinitionService.isInputRoute(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getInRouteId(ServiceTestEnum.CUSTOMER, "test"), null)), is(true));
+    }
+}

--- a/core/src/test/java/org/openhubframework/openhub/core/common/route/RouteTypeInRouteIdResolverTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/route/RouteTypeInRouteIdResolverTest.java
@@ -1,0 +1,47 @@
+package org.openhubframework.openhub.core.common.route;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.openhubframework.openhub.api.configuration.CoreProps.URI_INPUT_PATTERN_FILTER;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import org.openhubframework.openhub.api.route.AbstractBasicRoute;
+import org.openhubframework.openhub.api.route.RouteTypeInfo;
+import org.openhubframework.openhub.core.AbstractCoreTest;
+import org.openhubframework.openhub.test.data.ExternalSystemTestEnum;
+import org.openhubframework.openhub.test.data.ServiceTestEnum;
+
+/**
+ * Test for {@link RouteTypeInRouteIdResolver}.
+ *
+ * @author Roman Havlicek
+ * @see RouteTypeInRouteIdResolver
+ * @since 2.0
+ */
+@TestPropertySource(properties = {URI_INPUT_PATTERN_FILTER + "=direct:inputUri"})
+public class RouteTypeInRouteIdResolverTest extends AbstractCoreTest {
+
+    @Autowired
+    private RouteTypeInRouteIdResolver routeTypeInRouteIdResolver;
+
+    /**
+     * Test for method {@link RouteTypeInRouteIdResolver#findRouteType(RouteTypeInfo)}.
+     */
+    @Test
+    public void testFindRouteTypeForRoute() {
+        assertThat(routeTypeInRouteIdResolver.findRouteType(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getRouteId(ServiceTestEnum.CUSTOMER, "operation"), null)), nullValue());
+        assertThat(routeTypeInRouteIdResolver.findRouteType(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getExternalRouteId(ExternalSystemTestEnum.CRM, "operation"), null)), nullValue());
+        assertThat(routeTypeInRouteIdResolver.findRouteType(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getOutRouteId(ServiceTestEnum.ACCOUNT, "operation"), null)), nullValue());
+        assertThat(routeTypeInRouteIdResolver.findRouteType(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getInRouteId(ServiceTestEnum.ACCOUNT, "operation"), null)), is(RouteTypeEnum.INPUT));
+        assertThat(routeTypeInRouteIdResolver.findRouteType(new RouteTypeInfo(null, null,
+                AbstractBasicRoute.getInRouteId(ServiceTestEnum.CUSTOMER, "test"), null)), is(RouteTypeEnum.INPUT));
+    }
+}

--- a/core/src/test/java/org/openhubframework/openhub/core/common/route/RouteTypeUriResolverTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/route/RouteTypeUriResolverTest.java
@@ -1,0 +1,67 @@
+package org.openhubframework.openhub.core.common.route;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.openhubframework.openhub.api.configuration.CoreProps.URI_INPUT_PATTERN_FILTER;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import org.openhubframework.openhub.api.route.AbstractBasicRoute;
+import org.openhubframework.openhub.api.route.RouteTypeInfo;
+import org.openhubframework.openhub.core.AbstractCoreTest;
+
+/**
+ * Test for {@link RouteTypeUriResolver}.
+ *
+ * @author Roman Havlicek
+ * @see RouteTypeUriResolver
+ * @since 2.0
+ */
+@TestPropertySource(properties = {URI_INPUT_PATTERN_FILTER + "=direct:.*input.*"})
+public class RouteTypeUriResolverTest extends AbstractCoreTest {
+
+    @Autowired
+    private RouteTypeUriResolver routeTypeUriResolver;
+
+    /**
+     * Test for method {@link RouteTypeUriResolver#findRouteType(RouteTypeInfo)}.
+     */
+    @Test
+    public void testFindRouteTypeForRoute() throws Exception {
+        getCamelContext().addRoutes(new AbstractBasicRoute() {
+            @Override
+            protected void doConfigure() throws Exception {
+                from("direct:inputRoute")
+                        .routeId("inputTestRouteOne")
+                        .log("TestRoute");
+
+                from("direct:inputUri")
+                        .routeId("inputTestRouteTwo")
+                        .log("TestRoute");
+
+                from("direct:outputRoute")
+                        .routeId("outputTestRouteOne")
+                        .log("TestRoute");
+            }
+        });
+        assertThat(routeTypeUriResolver.findRouteType(
+                        new RouteTypeInfo(getCamelContext().getRoute("inputTestRouteOne"), null, null, null)),
+                is(RouteTypeEnum.INPUT));
+        assertThat(routeTypeUriResolver.findRouteType(
+                        new RouteTypeInfo(getCamelContext().getRoute("inputTestRouteTwo"), null, null, null)),
+                is(RouteTypeEnum.INPUT));
+        assertThat(routeTypeUriResolver.findRouteType(
+                        new RouteTypeInfo(getCamelContext().getRoute("outputTestRouteOne"), null, null, null)),
+                nullValue());
+
+        assertThat(routeTypeUriResolver.findRouteType(new RouteTypeInfo(null, null, null,
+                getCamelContext().getRouteDefinition("inputTestRouteOne"))), is(RouteTypeEnum.INPUT));
+        assertThat(routeTypeUriResolver.findRouteType(new RouteTypeInfo(null, null, null,
+                getCamelContext().getRouteDefinition("inputTestRouteTwo"))), is(RouteTypeEnum.INPUT));
+        assertThat(routeTypeUriResolver.findRouteType(new RouteTypeInfo(null, null, null,
+                getCamelContext().getRouteDefinition("outputTestRouteOne"))), nullValue());
+    }
+}


### PR DESCRIPTION
Problem:
When node is stopped, then only asynchronous requests are rejected. Synchronous requests node always processed.

Solutions:
Requests that will be rejected, when node is stopped, are recognized by input URI. This URI is identified by regular expression. This regular expression is stored in property ohf.uri.inputPatter.
When route starts and it is route with input URI, then HandleMessagePolicy is created. When node is stopped, this policy throws an exception.

For getting information about route type (input, output etc.) use RoudeDefinitionService. Default implementation of this service searchs route type in all implementations RouteTypeResolver.

JIRA:
https://openhubframework.atlassian.net/browse/OHFJIRA-45