### PR TITLE
Catalog API implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,24 @@
 # Welcome to OpenHub Framework 
 [![Build Status](https://travis-ci.org/OpenWiseSolutions/openhub-framework.svg?branch=develop)](https://travis-ci.org/OpenWiseSolutions/openhub-framework) [![Coverage Status](https://coveralls.io/repos/github/OpenWiseSolutions/openhub-framework/badge.svg?branch=develop)](https://coveralls.io/github/OpenWiseSolutions/openhub-framework?branch=develop) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.openhubframework/openhub/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.openhubframework/openhub)
 
-**ESB made by developers for developers**
+## Apache Camel, but improved
 
--     Open-source ESB with community development.
--     No limits for distribution.
--     Real life needs turned into framework.
--     Focus on maximum reliability during operation.
--     Simplicity and high speed of the development.
--     Maximum reuse of the code.
--     100% control over the code.
--     Active architectural governance.
+* open source
+* power of Apache Camel community
+* proven application stack
+* asynchronous messaging model
+* cluster support
+* own administration console
+* technologically neutral
+* enterprise ready
 
+We believe OpenHub framework is useful and effective integration framework, see [WHY]. **Don't hesitate and [try it].**
 
-Have you already noticed that most of integration projects consist of 80% from routine and only 20% are really new topics? Do you really want to spend so much effort on things which have already been solved before ? We don't.
-
-In OpenHub world most of the operational infrastructure is ready out of the box. Also typical coding scenarios can be generated and only adjusted if you need to. And when you code something, there is a big chance that somebody already did the same before.  We offer you to profit from the wide community, not to code, just install.
-Also repeating business scenarios can be downloaded from the catalogue and just plugged in into  your project.
-
-And if you really face to something special and new, OpenHub does not limit you in any direction. There are no dark corners in your project. Who has ever had to deal with black box, sure understands ....
-
-With OpenHub you have the whole source code in your hands and the community around, with many people ready to help.
-
-## License
+### License
 
 [Apache License 2.0]
 
-## Getting Started
+### Getting Started
 To help you get started, try the following links:
 
 * [how to start]
@@ -44,10 +36,12 @@ Enjoy!
 The OpenHub team!
 
 
+[WHY]:https://openhubframework.atlassian.net/wiki/spaces/OHF/pages/33600
+[try it]:https://openhubframework.atlassian.net/wiki/spaces/OHF/pages/33662/
 [Apache License 2.0]: http://www.apache.org/licenses/LICENSE-2.0.txt
 [how to start]: https://openhubframework.atlassian.net/wiki/display/OHF/Getting+started
 [building]: https://openhubframework.atlassian.net/wiki/x/foM
 [contributions]: https://github.com/OpenWiseSolutions/openhub-framework/blob/master/CONTRIBUTING.md
 [issue tracker]: https://openhubframework.atlassian.net/projects/OHFJIRA
-[wiki]: https://openwise.atlassian.net/projects/OHFJIRA
+[wiki]: https://openhubframework.atlassian.net/wiki
 [OpenHub Framework StackOverflow]: http://stackoverflow.com/questions/tagged/openhubframework

--- a/core-api/src/main/java/org/openhubframework/openhub/api/catalog/Catalog.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/catalog/Catalog.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.api.catalog;
+
+import java.util.List;
+
+import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.core.annotation.AnnotationUtils;
+
+
+/**
+ * Contract for OpenHub catalogs. All catalogs that should be available through
+ * catalog API, should be beans implementing this interface.
+ * Note: designed to be used with helper annotation {@link CatalogComponent}.
+ *
+ * @author Karel Kovarik
+ * @since 2.0
+ * @see CatalogComponent
+ */
+public interface Catalog {
+
+    /**
+     * Get all entries in catalog.
+     */
+    List<CatalogEntry> getEntries();
+
+    /**
+     * Resolve catalog name. Default implementation gets name from CatalogComponent
+     * annotation, if not found, class simpleName is used.
+     */
+    default String getName() {
+        final CatalogComponent annotation = AnnotationUtils.findAnnotation(
+                AopProxyUtils.ultimateTargetClass(this), CatalogComponent.class);
+
+        if (annotation != null) {
+            return annotation.value();
+        } else {
+            return getClass().getSimpleName();
+        }
+    }
+}

--- a/core-api/src/main/java/org/openhubframework/openhub/api/catalog/CatalogComponent.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/catalog/CatalogComponent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.api.catalog;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * Annotation for implementations of {@link Catalog} interface.
+ * It contains catalog name, and does include spring {@link Component} as well.
+ * @author Karel Kovarik
+ * @since 2.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface CatalogComponent {
+
+    /**
+     * The value is catalog name, as it will be available through the Catalog API.
+     *
+     * @return the catalog name.
+     */
+    @AliasFor("name")
+    String value() default "";
+
+    /**
+     * @see #value()
+     */
+    @AliasFor("value")
+    String name() default "";
+}

--- a/core-api/src/main/java/org/openhubframework/openhub/api/catalog/CatalogEntry.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/catalog/CatalogEntry.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.api.catalog;
+
+/**
+ * Contract for catalog entries.
+ *
+ * @author Karel Kovarik
+ * @since 2.0
+ */
+public interface CatalogEntry {
+
+    /**
+     * Code of catalog entry.
+     */
+    String getCode();
+
+    /**
+     * Description of catalog entry.
+     */
+    String getDescription();
+}

--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/catalog/CatalogService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/catalog/CatalogService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.spi.catalog;
+
+import java.util.List;
+
+import org.openhubframework.openhub.api.catalog.CatalogEntry;
+
+
+/**
+ * Service to provide OpenHub catalogs.
+ *
+ * @author Karel Kovarik
+ * @since 2.0
+ */
+public interface CatalogService {
+
+    /**
+     * Fetch all entries from catalog identified by name.
+     * @param catalogName the catalog name.
+     * @return list of all entries.
+     */
+    List<CatalogEntry> getEntries(String catalogName);
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/catalog/CatalogServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/catalog/CatalogServiceImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.catalog;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Optional;
+
+import org.openhubframework.openhub.api.catalog.Catalog;
+import org.openhubframework.openhub.api.catalog.CatalogEntry;
+import org.openhubframework.openhub.spi.catalog.CatalogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+
+/**
+ * Default implementation of {@link CatalogService}.
+ *
+ * @author Karel Kovarik
+ * @since 2.0
+ */
+@Service
+public class CatalogServiceImpl implements CatalogService {
+
+    @Autowired
+    private Optional<List<Catalog>> catalogList;
+
+    @Override
+    public List<CatalogEntry> getEntries(final String catalogName) {
+        Assert.hasText(catalogName, "the catalog name must not be empty!");
+
+        return catalogList.flatMap(
+                catalog -> catalog.stream()
+                        // find catalog with given name
+                        .filter(c -> catalogName.equalsIgnoreCase(c.getName()))
+                        .findFirst()
+                        .map(Catalog::getEntries))
+                // if catalog with given name was not found, throw IllegalArgumentException.
+                .orElseThrow(() ->
+                        new IllegalArgumentException(MessageFormat.format("Catalog with name {0} was not found.", catalogName))
+                );
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/catalog/SimpleCatalogEntry.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/catalog/SimpleCatalogEntry.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.catalog;
+
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openhubframework.openhub.api.catalog.CatalogEntry;
+import org.springframework.util.Assert;
+
+
+/**
+ * Simple implementation of {@link CatalogEntry}.
+ *
+ * @author Karel Kovarik
+ */
+public class SimpleCatalogEntry implements CatalogEntry {
+
+    private final String code;
+    private final String description;
+
+    public SimpleCatalogEntry(String code, String description) {
+        Assert.hasText(code, "the code must not be null");
+
+        this.code = code;
+        this.description = description;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SimpleCatalogEntry that = (SimpleCatalogEntry) o;
+
+        return new EqualsBuilder()
+                .append(code, that.code)
+                // only code
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(code)
+                // only code
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("code", code)
+                .append("description", description)
+                .toString();
+    }
+}

--- a/core/src/test/java/org/openhubframework/openhub/core/catalog/CatalogServiceImplTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/catalog/CatalogServiceImplTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.catalog;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.openhubframework.openhub.api.catalog.Catalog;
+import org.openhubframework.openhub.api.catalog.CatalogComponent;
+import org.openhubframework.openhub.api.catalog.CatalogEntry;
+import org.openhubframework.openhub.core.AbstractCoreTest;
+import org.openhubframework.openhub.spi.catalog.CatalogService;
+import org.openhubframework.openhub.test.data.ExternalSystemTestEnum;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+
+
+/**
+ * Simple test suite for {@link CatalogServiceImpl}.
+ *
+ * @author Karel Kovarik
+ */
+@ContextConfiguration(classes = {
+        CatalogServiceImpl.class,
+        CatalogServiceImplTest.SourceSystemTestCatalog.class
+})
+public class CatalogServiceImplTest extends AbstractCoreTest {
+
+    @Autowired
+    private CatalogService catalogService;
+
+    @Test
+    public void test_ok() {
+        final List<CatalogEntry> catalogEntries = catalogService.getEntries("sourceSystems");
+        assertThat(catalogEntries, hasSize(2));
+        assertThat(catalogEntries.get(0).getCode(), is("CRM"));
+        assertThat(catalogEntries.get(0).getDescription(), is("CRM system"));
+        assertThat(catalogEntries.get(1).getCode(), is("BILLING"));
+        assertThat(catalogEntries.get(1).getDescription(), is("Billing system"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void test_catalogNotFound() {
+        catalogService.getEntries("FAKE");
+    }
+
+    /**
+     * Simple test implementation of catalog.
+     */
+    @CatalogComponent("sourceSystems")
+    static class SourceSystemTestCatalog implements Catalog {
+
+        @Override
+        public List<CatalogEntry> getEntries() {
+            return Stream.of(
+                    new SimpleCatalogEntry(ExternalSystemTestEnum.CRM.getSystemName(), "CRM system"),
+                    new SimpleCatalogEntry(ExternalSystemTestEnum.BILLING.getSystemName(), "Billing system")
+            ).collect(Collectors.toList());
+        }
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/catalog/rest/CatalogController.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/catalog/rest/CatalogController.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.catalog.rest;
+
+import org.openhubframework.openhub.admin.web.catalog.rpc.CatalogEntryRpc;
+import org.openhubframework.openhub.admin.web.common.AbstractOhfController;
+import org.openhubframework.openhub.admin.web.common.rpc.CollectionWrapper;
+import org.openhubframework.openhub.spi.catalog.CatalogService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * Controller for OpenHub catalogs.
+ *
+ * @author Karel Kovarik
+ * @since 2.0
+ */
+@RestController
+@RequestMapping(CatalogController.REST_URI)
+public class CatalogController extends AbstractOhfController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CatalogController.class);
+
+    public static final String REST_URI = BASE_PATH + "/catalogs";
+
+    @Autowired
+    private CatalogService catalogService;
+
+    /**
+     * Get full catalog identified by its name.
+     *
+     * @param name the name of catalog.
+     * @return list of catalog entries, 404 response code if catalog is not found.
+     */
+    @GetMapping(path = "/{name}", produces = {"application/xml", "application/json"})
+    public ResponseEntity<CollectionWrapper<CatalogEntryRpc>> getCatalog(@PathVariable final String name) {
+        try {
+            return new ResponseEntity<>(new CollectionWrapper<>(
+                    CatalogEntryRpc.fromCatalogEntry(),
+                    catalogService.getEntries(name)), HttpStatus.OK
+            );
+        } catch (final IllegalArgumentException ex) {
+            LOG.info("Catalog service IllegalArgumentException: ", ex);
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/catalog/rpc/CatalogEntryRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/catalog/rpc/CatalogEntryRpc.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.catalog.rpc;
+
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openhubframework.openhub.api.catalog.CatalogEntry;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.Assert;
+
+/**
+ * Rpc with catalog entry.
+ *
+ * @author Karel Kovarik
+ * @since 2.0
+ */
+public class CatalogEntryRpc {
+
+    private final String code;
+    private final String description;
+
+    public CatalogEntryRpc(String code, String description) {
+        Assert.hasText(code, "the code must not be null");
+
+        this.code = code;
+        this.description = description;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Converter to convert domain object to rpc.
+     * @return Converter from {@link CatalogEntry} to {@link CatalogEntryRpc}.
+     * @see Converter
+     */
+    public static Converter<CatalogEntry, CatalogEntryRpc> fromCatalogEntry() {
+        return source -> new CatalogEntryRpc(source.getCode(), source.getDescription());
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("code", code)
+                .append("description", description)
+                .toString();
+    }
+}

--- a/web-admin/src/test/java/org/openhubframework/openhub/admin/web/catalog/rest/CatalogControllerTest.java
+++ b/web-admin/src/test/java/org/openhubframework/openhub/admin/web/catalog/rest/CatalogControllerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.admin.web.catalog.rest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.openhubframework.openhub.test.rest.TestRestUtils.createGetUrl;
+import static org.openhubframework.openhub.test.rest.TestRestUtils.toUrl;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Test;
+import org.openhubframework.openhub.admin.AbstractAdminModuleRestTest;
+import org.openhubframework.openhub.api.catalog.CatalogEntry;
+import org.openhubframework.openhub.core.catalog.SimpleCatalogEntry;
+import org.openhubframework.openhub.spi.catalog.CatalogService;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+
+
+/**
+ * Simple test suite for {@link CatalogController}.
+ *
+ * @author Karel Kovarik
+ * @since 2.0
+ */
+public class CatalogControllerTest extends AbstractAdminModuleRestTest {
+
+    @MockBean
+    private CatalogService catalogService;
+
+    @Test
+    public void getCatalog_ok() throws Exception {
+        final List<CatalogEntry> sourceSystems = Stream.of(
+                new SimpleCatalogEntry("CRM", "CRM system"),
+                new SimpleCatalogEntry("BILLING", "Billing system"))
+                .collect(Collectors.toList());
+        when(catalogService.getEntries(eq("sourceSystems")))
+                .thenReturn(sourceSystems);
+
+        final URIBuilder uriBuilder = createGetUrl(CatalogController.REST_URI + "/sourceSystems");
+
+        // GET /api/catalogs/sourceSystems
+        mockMvc.perform(get(toUrl(uriBuilder))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(2)))
+                .andExpect(jsonPath("$.data[0].code", is("CRM")))
+                .andExpect(jsonPath("$.data[0].description", is("CRM system")))
+                .andExpect(jsonPath("$.data[1].code", is("BILLING")))
+                .andExpect(jsonPath("$.data[1].description", is("Billing system")))
+        ;
+    }
+
+    @Test
+    public void getCatalog_noEntriesInCatalog() throws Exception {
+        when(catalogService.getEntries(eq("EMPTY_CATALOG")))
+                .thenReturn(Collections.emptyList());
+
+        final URIBuilder uriBuilder = createGetUrl(CatalogController.REST_URI + "/EMPTY_CATALOG");
+
+        // GET /api/catalogs/NOT_EXISTING
+        mockMvc.perform(get(toUrl(uriBuilder))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(0)))
+        ;
+    }
+
+    @Test
+    public void getCatalog_notExistingCatalog() throws Exception {
+        when(catalogService.getEntries(eq("NOT_EXISTING_CATALOG")))
+                .thenThrow(new IllegalArgumentException());
+
+        final URIBuilder uriBuilder = createGetUrl(CatalogController.REST_URI + "/NOT_EXISTING_CATALOG");
+
+        // GET /api/catalogs/NOT_EXISTING
+        mockMvc.perform(get(toUrl(uriBuilder))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isNotFound())
+        ;
+    }
+}


### PR DESCRIPTION
### CHANGES
* catalog api implementation added, in minimal scope that is needed for messages (OHFJIRA-57)
* it is fast & simple, only code & description for each catalog entry, no validity, localization or any advanced features.
* see CatalogServiceImplTest for example catalog implementation (SourceSystemTestCatalog)

### API
* http://docs.openhubframework.apiary.io/#reference/0/openhub-catalogs