### PR TITLE
OHFJIRA-57 Messages

### DIFF
--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/MessageActionType.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/MessageActionType.java
@@ -1,6 +1,24 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openhubframework.openhub.api.entity;
 
 /**
+ * Type of action that should be performed with messages.
+ *
  * @author Karel Kovarik
  */
 public enum MessageActionType {

--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/MessageActionType.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/MessageActionType.java
@@ -1,0 +1,9 @@
+package org.openhubframework.openhub.api.entity;
+
+/**
+ * @author Karel Kovarik
+ */
+public enum MessageActionType {
+    RESTART,
+    CANCEL
+}

--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/MessageFilter.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/MessageFilter.java
@@ -1,0 +1,140 @@
+package org.openhubframework.openhub.api.entity;
+
+import java.time.Instant;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+
+/**
+ * @author Karel Kovarik
+ */
+public class MessageFilter {
+
+    private Instant receivedFrom;
+    private Instant receivedTo;
+    private Instant lastChangeFrom;
+    private Instant lastChangeTo;
+    private String sourceSystem;
+    private String correlationId;
+    private String processId;
+    private MsgStateEnum state;
+    private String errorCode;
+    private String serviceName;
+    private String operationName;
+    private String fulltext;
+
+    public Instant getReceivedFrom() {
+        return receivedFrom;
+    }
+
+    public void setReceivedFrom(Instant receivedFrom) {
+        this.receivedFrom = receivedFrom;
+    }
+
+    public Instant getReceivedTo() {
+        return receivedTo;
+    }
+
+    public void setReceivedTo(Instant receivedTo) {
+        this.receivedTo = receivedTo;
+    }
+
+    public Instant getLastChangeFrom() {
+        return lastChangeFrom;
+    }
+
+    public void setLastChangeFrom(Instant lastChangeFrom) {
+        this.lastChangeFrom = lastChangeFrom;
+    }
+
+    public Instant getLastChangeTo() {
+        return lastChangeTo;
+    }
+
+    public void setLastChangeTo(Instant lastChangeTo) {
+        this.lastChangeTo = lastChangeTo;
+    }
+
+    public String getSourceSystem() {
+        return sourceSystem;
+    }
+
+    public void setSourceSystem(String sourceSystem) {
+        this.sourceSystem = sourceSystem;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+    public String getProcessId() {
+        return processId;
+    }
+
+    public void setProcessId(String processId) {
+        this.processId = processId;
+    }
+
+    public MsgStateEnum getState() {
+        return state;
+    }
+
+    public void setState(MsgStateEnum state) {
+        this.state = state;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
+    }
+
+    public String getFulltext() {
+        return fulltext;
+    }
+
+    public void setFulltext(String fulltext) {
+        this.fulltext = fulltext;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("receivedFrom", receivedFrom)
+                .append("receivedTo", receivedTo)
+                .append("lastChangeFrom", lastChangeFrom)
+                .append("lastChangeTo", lastChangeTo)
+                .append("sourceSystem", sourceSystem)
+                .append("correlationId", correlationId)
+                .append("processId", processId)
+                .append("state", state)
+                .append("errorCode", errorCode)
+                .append("serviceName", serviceName)
+                .append("operationName", operationName)
+                .append("fulltext", fulltext)
+                .toString();
+    }
+}

--- a/core-api/src/main/java/org/openhubframework/openhub/api/entity/MessageFilter.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/entity/MessageFilter.java
@@ -1,12 +1,32 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openhubframework.openhub.api.entity;
 
 import java.time.Instant;
+
+import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
 
 /**
+ * Filter for messages.
+ *
  * @author Karel Kovarik
  */
 public class MessageFilter {
@@ -32,6 +52,7 @@ public class MessageFilter {
         this.receivedFrom = receivedFrom;
     }
 
+    @Nullable
     public Instant getReceivedTo() {
         return receivedTo;
     }
@@ -40,6 +61,7 @@ public class MessageFilter {
         this.receivedTo = receivedTo;
     }
 
+    @Nullable
     public Instant getLastChangeFrom() {
         return lastChangeFrom;
     }
@@ -48,6 +70,7 @@ public class MessageFilter {
         this.lastChangeFrom = lastChangeFrom;
     }
 
+    @Nullable
     public Instant getLastChangeTo() {
         return lastChangeTo;
     }
@@ -56,6 +79,7 @@ public class MessageFilter {
         this.lastChangeTo = lastChangeTo;
     }
 
+    @Nullable
     public String getSourceSystem() {
         return sourceSystem;
     }
@@ -64,6 +88,7 @@ public class MessageFilter {
         this.sourceSystem = sourceSystem;
     }
 
+    @Nullable
     public String getCorrelationId() {
         return correlationId;
     }
@@ -72,6 +97,7 @@ public class MessageFilter {
         this.correlationId = correlationId;
     }
 
+    @Nullable
     public String getProcessId() {
         return processId;
     }
@@ -80,6 +106,7 @@ public class MessageFilter {
         this.processId = processId;
     }
 
+    @Nullable
     public MsgStateEnum getState() {
         return state;
     }
@@ -88,6 +115,7 @@ public class MessageFilter {
         this.state = state;
     }
 
+    @Nullable
     public String getErrorCode() {
         return errorCode;
     }
@@ -96,6 +124,7 @@ public class MessageFilter {
         this.errorCode = errorCode;
     }
 
+    @Nullable
     public String getServiceName() {
         return serviceName;
     }
@@ -104,6 +133,7 @@ public class MessageFilter {
         this.serviceName = serviceName;
     }
 
+    @Nullable
     public String getOperationName() {
         return operationName;
     }
@@ -112,6 +142,7 @@ public class MessageFilter {
         this.operationName = operationName;
     }
 
+    @Nullable
     public String getFulltext() {
         return fulltext;
     }

--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
@@ -32,6 +32,7 @@ import org.apache.camel.Properties;
 
 import org.openhubframework.openhub.api.entity.ExternalSystemExtEnum;
 import org.openhubframework.openhub.api.entity.Message;
+import org.openhubframework.openhub.api.entity.MessageFilter;
 import org.openhubframework.openhub.api.entity.MsgStateEnum;
 import org.openhubframework.openhub.api.exception.ErrorExtEnum;
 
@@ -192,6 +193,14 @@ public interface MessageService {
      * @return list of messages or {@code empty list} if not found messages with substring in payload property
      */
     List<Message> findMessagesByContent(String substring);
+
+
+    /**
+     * Find list of messages that match with given filter.
+     * @param messageFilter the filter.
+     * @return collection of messages, or {@code empty list} if none were found.
+     */
+    List<Message> findMessagesByFilter(MessageFilter messageFilter);
 
     /**
      * Get count of messages in specific state.

--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
@@ -196,11 +196,13 @@ public interface MessageService {
 
 
     /**
-     * Find list of messages that match with given filter.
+     * Finds list of messages that match with given filter. Sorted by received timestamp (newest first).
+     *
      * @param messageFilter the filter.
+     * @param limit the limit of message count.
      * @return collection of messages, or {@code empty list} if none were found.
      */
-    List<Message> findMessagesByFilter(MessageFilter messageFilter);
+    List<Message> findMessagesByFilter(MessageFilter messageFilter, long limit);
 
     /**
      * Get count of messages in specific state.

--- a/core/src/main/java/org/openhubframework/openhub/core/catalog/MessageStateCatalog.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/catalog/MessageStateCatalog.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.catalog;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.openhubframework.openhub.api.catalog.Catalog;
+import org.openhubframework.openhub.api.catalog.CatalogComponent;
+import org.openhubframework.openhub.api.catalog.CatalogEntry;
+import org.openhubframework.openhub.api.entity.MsgStateEnum;
+
+
+/**
+ * Catalog implementation, for message states.
+ *
+ * @author Karel Kovarik
+ * @see Catalog
+ */
+@CatalogComponent(MessageStateCatalog.NAME)
+public class MessageStateCatalog implements Catalog {
+
+    // catalog name
+    static final String NAME = "messageState";
+
+    @Override
+    public List<CatalogEntry> getEntries() {
+        return Arrays.stream(MsgStateEnum.values())
+                // code & description directly from MsgStateEnum
+                .map(stateEnum -> new SimpleCatalogEntry(stateEnum.name(), stateEnum.name()))
+                .collect(Collectors.toList());
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/catalog/SimpleCatalogEntry.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/catalog/SimpleCatalogEntry.java
@@ -36,7 +36,7 @@ public class SimpleCatalogEntry implements CatalogEntry {
     private final String code;
     private final String description;
 
-    public SimpleCatalogEntry(String code, String description) {
+    public SimpleCatalogEntry(String code, @Nullable String description) {
         Assert.hasText(code, "the code must not be null");
 
         this.code = code;

--- a/core/src/main/java/org/openhubframework/openhub/core/catalog/SourceSystemCatalog.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/catalog/SourceSystemCatalog.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.catalog;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.openhubframework.openhub.api.catalog.Catalog;
+import org.openhubframework.openhub.api.catalog.CatalogComponent;
+import org.openhubframework.openhub.api.catalog.CatalogEntry;
+
+
+/**
+ * Catalog implementation, for source systems.
+ *
+ * @author Karel Kovarik
+ */
+@CatalogComponent(SourceSystemCatalog.NAME)
+public class SourceSystemCatalog implements Catalog {
+
+    static final String NAME = "sourceSystem";
+
+    @Override
+    public List<CatalogEntry> getEntries() {
+        return Collections.singletonList(
+                new SimpleCatalogEntry("UNDEFINED", "UNDEFINED")
+        );
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageHelper.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageHelper.java
@@ -16,12 +16,19 @@
 
 package org.openhubframework.openhub.core.common.asynch.msg;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.openhubframework.openhub.api.entity.MessageActionType;
+import org.openhubframework.openhub.api.entity.MsgStateEnum;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +43,30 @@ import org.openhubframework.openhub.api.entity.Message;
 public final class MessageHelper {
 
     private static final Logger LOG = LoggerFactory.getLogger(MessageHelper.class);
+
+    /**
+     * States in which RESTART operation is available.
+     */
+    private static final Set<MsgStateEnum> RESTART_STATES = Stream.of(MsgStateEnum.OK, MsgStateEnum.FAILED, MsgStateEnum.CANCEL)
+            .collect(Collectors.toSet());
+    /**
+     * States valid for CANCEL operation.
+     */
+    private static final Set<MsgStateEnum> CANCEL_STATES = Stream.of(MsgStateEnum.values())
+            .filter(state -> !RESTART_STATES.contains(state))
+            .collect(Collectors.toSet());
+
+    /**
+     * Map with ACTION and STATES in which the ACTION can be performed on given message.
+     */
+    private static final Map<MessageActionType, Set<MsgStateEnum>> ACTION_TYPES = Collections.unmodifiableMap(Stream.of(
+            new AbstractMap.SimpleImmutableEntry<>(MessageActionType.CANCEL, CANCEL_STATES),
+            new AbstractMap.SimpleImmutableEntry<>(MessageActionType.RESTART, RESTART_STATES))
+            .collect(Collectors.toMap(
+                    AbstractMap.SimpleImmutableEntry::getKey,
+                    AbstractMap.SimpleImmutableEntry::getValue)
+            )
+    );
 
     private MessageHelper() {
     }
@@ -74,5 +105,16 @@ public final class MessageHelper {
 
         String businessErrors = StringUtils.join(errorList, Message.ERR_DESC_SEPARATOR);
         msg.setBusinessError(businessErrors);
+    }
+
+    /**
+     * Get allowed actions for message.
+     * @param message the message entity.
+     * @return list of action types.
+     */
+    public static List<MessageActionType> allowedActions(final Message message) {
+        return ACTION_TYPES.keySet().stream()
+                .filter(key -> ACTION_TYPES.get(key).contains(message.getState()))
+                .collect(Collectors.toList());
     }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageHelper.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageHelper.java
@@ -16,9 +16,8 @@
 
 package org.openhubframework.openhub.core.common.asynch.msg;
 
-import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import org.openhubframework.openhub.api.asynch.AsynchConstants;
 import org.openhubframework.openhub.api.entity.Message;
+import org.springframework.util.Assert;
 
 
 /**
@@ -59,14 +59,11 @@ public final class MessageHelper {
     /**
      * Map with ACTION and STATES in which the ACTION can be performed on given message.
      */
-    private static final Map<MessageActionType, Set<MsgStateEnum>> ACTION_TYPES = Collections.unmodifiableMap(Stream.of(
-            new AbstractMap.SimpleImmutableEntry<>(MessageActionType.CANCEL, CANCEL_STATES),
-            new AbstractMap.SimpleImmutableEntry<>(MessageActionType.RESTART, RESTART_STATES))
-            .collect(Collectors.toMap(
-                    AbstractMap.SimpleImmutableEntry::getKey,
-                    AbstractMap.SimpleImmutableEntry::getValue)
-            )
-    );
+    private static final Map<MessageActionType, Set<MsgStateEnum>> ACTION_TYPES = new HashMap<>();
+    static {
+        ACTION_TYPES.put(MessageActionType.CANCEL, CANCEL_STATES);
+        ACTION_TYPES.put(MessageActionType.RESTART, RESTART_STATES);
+    }
 
     private MessageHelper() {
     }
@@ -109,10 +106,13 @@ public final class MessageHelper {
 
     /**
      * Get allowed actions for message.
+     *
      * @param message the message entity.
      * @return list of action types.
      */
     public static List<MessageActionType> allowedActions(final Message message) {
+        Assert.notNull(message, "the message must not be null.");
+
         return ACTION_TYPES.keySet().stream()
                 .filter(key -> ACTION_TYPES.get(key).contains(message.getState()))
                 .collect(Collectors.toList());

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
@@ -437,10 +437,10 @@ public class MessageServiceImpl implements MessageService {
     }
 
     @Override
-    public List<Message> findMessagesByFilter(final MessageFilter messageFilter) {
+    public List<Message> findMessagesByFilter(final MessageFilter messageFilter, long limit) {
         Assert.notNull(messageFilter, "the messageFilter must not be null");
 
-        return messageDao.findMessagesByFilter(messageFilter);
+        return messageDao.findMessagesByFilter(messageFilter, limit);
     }
 
     @Override

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.openhubframework.openhub.api.entity.MessageFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -433,6 +434,13 @@ public class MessageServiceImpl implements MessageService {
         Assert.hasText(substring, "the substring must not be empty");
 
         return messageDao.findMessagesByContent(substring);
+    }
+
+    @Override
+    public List<Message> findMessagesByFilter(final MessageFilter messageFilter) {
+        Assert.notNull(messageFilter, "the messageFilter must not be null");
+
+        return messageDao.findMessagesByFilter(messageFilter);
     }
 
     @Override

--- a/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
@@ -199,5 +199,12 @@ public interface MessageDao {
      */
     List<Message> findMessagesByContent(String substring);
 
-    List<Message> findMessagesByFilter(MessageFilter messageFilter);
+    /**
+     * Finds messages by multiple fields, hold together in MessageFilter.
+     *
+     * @param messageFilter the filter.
+     * @param limit the limit of messages.
+     * @return list of messages.
+     */
+    List<Message> findMessagesByFilter(MessageFilter messageFilter, long limit);
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 
 import org.openhubframework.openhub.api.entity.ExternalSystemExtEnum;
 import org.openhubframework.openhub.api.entity.Message;
+import org.openhubframework.openhub.api.entity.MessageFilter;
 import org.openhubframework.openhub.api.entity.MsgStateEnum;
 import org.openhubframework.openhub.api.entity.Node;
 
@@ -197,4 +198,6 @@ public interface MessageDao {
      * @return list of message or {@code empty list} if not available
      */
     List<Message> findMessagesByContent(String substring);
+
+    List<Message> findMessagesByFilter(MessageFilter messageFilter);
 }

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/msg/MessageHelperTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/msg/MessageHelperTest.java
@@ -1,0 +1,61 @@
+package org.openhubframework.openhub.core.common.asynch.msg;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.openhubframework.openhub.core.common.asynch.msg.MessageHelper.allowedActions;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.openhubframework.openhub.api.entity.Message;
+import org.openhubframework.openhub.api.entity.MessageActionType;
+import org.openhubframework.openhub.api.entity.MsgStateEnum;
+import org.openhubframework.openhub.test.data.ExternalSystemTestEnum;
+import org.openhubframework.openhub.test.data.ServiceTestEnum;
+
+
+/**
+ * @author Karel Kovarik
+ */
+public class MessageHelperTest {
+
+    @Test
+    public void test_allowedActions() {
+        assertThat(allowedActions(createMessage(MsgStateEnum.NEW)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.OK)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.OK)).contains(MessageActionType.RESTART),
+                is(Boolean.TRUE));
+        assertThat(allowedActions(createMessage(MsgStateEnum.IN_QUEUE)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.PROCESSING)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.PARTLY_FAILED)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.FAILED)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.FAILED)).contains(MessageActionType.RESTART),
+                is(Boolean.TRUE));
+        assertThat(allowedActions(createMessage(MsgStateEnum.WAITING)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.WAITING_FOR_RES)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.POSTPONED)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.CANCEL)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.CANCEL)).contains(MessageActionType.RESTART),
+                is(Boolean.TRUE));
+    }
+
+    protected Message createMessage(MsgStateEnum stateEnum) {
+        Message msg = new Message();
+
+        Instant now = Instant.now();
+        msg.setState(stateEnum);
+        msg.setMsgTimestamp(now);
+        msg.setReceiveTimestamp(now);
+        msg.setSourceSystem(ExternalSystemTestEnum.CRM);
+        msg.setCorrelationId(UUID.randomUUID().toString());
+
+        msg.setService(ServiceTestEnum.CUSTOMER);
+        msg.setOperationName("helloWorld");
+        msg.setPayload("test-payload");
+        msg.setLastUpdateTimestamp(now);
+
+        return msg;
+    }
+}

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/msg/MessageHelperTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/msg/MessageHelperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openhubframework.openhub.core.common.asynch.msg;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -17,6 +33,8 @@ import org.openhubframework.openhub.test.data.ServiceTestEnum;
 
 
 /**
+ * Test suite for {@link MessageHelper}.
+ *
  * @author Karel Kovarik
  */
 public class MessageHelperTest {
@@ -24,18 +42,30 @@ public class MessageHelperTest {
     @Test
     public void test_allowedActions() {
         assertThat(allowedActions(createMessage(MsgStateEnum.NEW)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.NEW)).contains(MessageActionType.CANCEL),
+                is(Boolean.TRUE));
         assertThat(allowedActions(createMessage(MsgStateEnum.OK)), hasSize(1));
         assertThat(allowedActions(createMessage(MsgStateEnum.OK)).contains(MessageActionType.RESTART),
                 is(Boolean.TRUE));
         assertThat(allowedActions(createMessage(MsgStateEnum.IN_QUEUE)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.IN_QUEUE)).contains(MessageActionType.CANCEL),
+                is(Boolean.TRUE));
         assertThat(allowedActions(createMessage(MsgStateEnum.PROCESSING)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.PROCESSING)).contains(MessageActionType.CANCEL),
+                is(Boolean.TRUE));
         assertThat(allowedActions(createMessage(MsgStateEnum.PARTLY_FAILED)), hasSize(1));
         assertThat(allowedActions(createMessage(MsgStateEnum.FAILED)), hasSize(1));
         assertThat(allowedActions(createMessage(MsgStateEnum.FAILED)).contains(MessageActionType.RESTART),
                 is(Boolean.TRUE));
         assertThat(allowedActions(createMessage(MsgStateEnum.WAITING)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.WAITING)).contains(MessageActionType.CANCEL),
+                is(Boolean.TRUE));
         assertThat(allowedActions(createMessage(MsgStateEnum.WAITING_FOR_RES)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.WAITING_FOR_RES)).contains(MessageActionType.CANCEL),
+                is(Boolean.TRUE));
         assertThat(allowedActions(createMessage(MsgStateEnum.POSTPONED)), hasSize(1));
+        assertThat(allowedActions(createMessage(MsgStateEnum.POSTPONED)).contains(MessageActionType.CANCEL),
+                is(Boolean.TRUE));
         assertThat(allowedActions(createMessage(MsgStateEnum.CANCEL)), hasSize(1));
         assertThat(allowedActions(createMessage(MsgStateEnum.CANCEL)).contains(MessageActionType.RESTART),
                 is(Boolean.TRUE));

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceTest.java
@@ -228,7 +228,7 @@ public class MessageServiceTest extends AbstractCoreDbTest {
 
         final MessageFilter filter = new MessageFilter();
         filter.setReceivedFrom(LocalDateTime.of(2017,5,27,19,17,10).toInstant(ZoneOffset.UTC));
-        List<Message> dbMessages = messageService.findMessagesByFilter(filter);
+        List<Message> dbMessages = messageService.findMessagesByFilter(filter, 100L);
         assertThat(dbMessages.size(), is(1));
         assertThat(dbMessages.get(0).getPayload(), is("message-payload"));
     }
@@ -282,7 +282,7 @@ public class MessageServiceTest extends AbstractCoreDbTest {
         filter.setServiceName(ServiceTestEnum.CUSTOMER.getServiceName());
         filter.setOperationName("testOperation");
         filter.setFulltext("test payload");
-        assertThat(messageService.findMessagesByFilter(filter).size(), is(1));
+        assertThat(messageService.findMessagesByFilter(filter, 100L).size(), is(1));
     }
 
     @Test
@@ -297,7 +297,7 @@ public class MessageServiceTest extends AbstractCoreDbTest {
         final MessageFilter filter = new MessageFilter();
         filter.setReceivedFrom(LocalDateTime.of(2017,5,27,19,17,10).toInstant(ZoneOffset.UTC));
         filter.setCorrelationId("11111-22222-33333");
-        List<Message> dbMessages = messageService.findMessagesByFilter(filter);
+        List<Message> dbMessages = messageService.findMessagesByFilter(filter, 100L);
         assertThat(dbMessages.size(), is(1));
     }
 
@@ -317,7 +317,7 @@ public class MessageServiceTest extends AbstractCoreDbTest {
         final MessageFilter filter = new MessageFilter();
         filter.setReceivedFrom(LocalDateTime.of(2017,5,27,19,17,10).toInstant(ZoneOffset.UTC));
         filter.setFulltext("car");
-        assertThat(messageService.findMessagesByFilter(filter).size(), is(3));
+        assertThat(messageService.findMessagesByFilter(filter, 100L).size(), is(3));
     }
 
     private static void findByFilter_messageFill(final Message msg) {

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/catalog/rpc/CatalogEntryRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/catalog/rpc/CatalogEntryRpc.java
@@ -35,7 +35,7 @@ public class CatalogEntryRpc {
     private final String code;
     private final String description;
 
-    public CatalogEntryRpc(String code, String description) {
+    public CatalogEntryRpc(String code, @Nullable String description) {
         Assert.hasText(code, "the code must not be null");
 
         this.code = code;

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rest/MessageController.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rest/MessageController.java
@@ -1,9 +1,31 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openhubframework.openhub.admin.web.message.rest;
 
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Optional;
 
+import javax.validation.Valid;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import org.openhubframework.openhub.admin.web.common.AbstractOhfController;
+import org.openhubframework.openhub.admin.web.message.rpc.ActionRequestRpc;
+import org.openhubframework.openhub.admin.web.message.rpc.ActionResultRpc;
 import org.openhubframework.openhub.admin.web.message.rpc.MessageFilterRpc;
 import org.openhubframework.openhub.admin.web.message.rpc.MessageCollectionWrapper;
 import org.openhubframework.openhub.admin.web.message.rpc.MessageListItemRpc;
@@ -13,8 +35,9 @@ import org.openhubframework.openhub.api.configuration.ConfigurableValue;
 import org.openhubframework.openhub.api.configuration.ConfigurationItem;
 import org.openhubframework.openhub.api.entity.Message;
 import org.openhubframework.openhub.api.entity.MessageFilter;
-import org.openhubframework.openhub.common.OpenHubPropertyConstants;
+import org.openhubframework.openhub.core.common.asynch.msg.MessageOperationService;
 import org.openhubframework.openhub.spi.msg.MessageService;
+import org.openhubframework.openhub.web.common.WebProps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,15 +45,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Controller for managing operation with messages.
+ * Controller for managing operations with messages.
  *
  * @author Karel Kovarik
+ * @since 2.0
  */
 @RestController
 @RequestMapping(value = MessageController.REST_URI)
@@ -40,42 +66,50 @@ public class MessageController extends AbstractOhfController {
 
     public static final String REST_URI = BASE_PATH + "/messages";
 
-    private static final String MESSAGES_LIMIT_PROPERTY = OpenHubPropertyConstants.PREFIX + "admin.console.messages.limit";
+    private static final String MESSAGE_ACTION_OK = "OK";
 
-    @ConfigurableValue(key = MESSAGES_LIMIT_PROPERTY)
+    private static final String MESSAGE_ACTION_ERROR = "ERROR";
+
+    @ConfigurableValue(key = WebProps.MESSAGES_LIMIT)
     private ConfigurationItem<Long> messagesLimit;
 
     @Autowired
     private MessageService messageService;
 
+    @Autowired
+    private MessageOperationService messageOperationService;
+
     /**
      * List messages, by given filter.
+     *
      * @param messageFilter the filter to filter messages.
      * @return custom collection wrapper with messagelist elemenets.
      */
     @GetMapping(produces = {"application/xml", "application/json"})
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
-    public MessageCollectionWrapper<MessageListItemRpc> list(final MessageFilterRpc messageFilter){
+    public MessageCollectionWrapper list(final MessageFilterRpc messageFilter){
         Constraints.notNull(messageFilter.getReceivedFrom(), "The receivedFrom is mandatory.");
+        Constraints.notNull(messagesLimit.getValue(), "the messagesLimit must be configured.");
 
         final MessageFilter filter =
                 MessageFilterRpc.toMessageFilter().convert(messageFilter);
         LOG.trace("List messages by filter [{}].", filter);
 
         // fetch messages from messageService
-        final List<Message> messageList = messageService.findMessagesByFilter(filter);
+        final List<Message> messageList = messageService.findMessagesByFilter(filter, messagesLimit.getValue());
 
-        return new MessageCollectionWrapper<>(
+        return new MessageCollectionWrapper(
                 MessageListItemRpc.fromMessage(),
                 messageList,
-                messagesLimit.getValue(0L),
+                messagesLimit.getValue(),
                 messageList.size()
         );
     }
 
     /**
      * Get detail of message identified by its id.
+     *
      * @param id the id of message.
      * @return message detail.
      */
@@ -90,5 +124,47 @@ public class MessageController extends AbstractOhfController {
                 .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
     }
 
-    // action TBA
+    /**
+     * Perform action on message identified by its id.
+     *
+     * @param id the id of message to perform action on.
+     * @param actionRequestRpc the action type.
+     * @return ActionResultRpc entity.
+     */
+    @PostMapping(path = "/{id}/action", produces = {"application/xml", "application/json"})
+    public ResponseEntity<ActionResultRpc> action(
+            @PathVariable final Long id,
+            @RequestBody @Valid final ActionRequestRpc actionRequestRpc) {
+
+        try {
+            switch(actionRequestRpc.getType()) {
+                case CANCEL:
+                    messageOperationService.cancelMessage(id);
+                    return new ResponseEntity<>(
+                            new ActionResultRpc(MESSAGE_ACTION_OK, "Successful message cancel."), HttpStatus.OK);
+                case RESTART:
+                    final JsonNode totalRestartNode = actionRequestRpc.getData().get(ActionRequestRpc.TOTAL_RESTART_FIELD);
+                    return totalRestartNode != null ? restartMessage(id, totalRestartNode.asBoolean())
+                                                    : new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+                default:
+                    // unsupported action
+                    return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            }
+
+        // catch IllegalStateException, return it as 419 CONFLICT
+        } catch (final IllegalStateException ex) {
+            LOG.warn("Unable to perform action on message with id [{}], actionRequest [{}]:", id, actionRequestRpc, ex);
+            return new ResponseEntity<>(
+                    new ActionResultRpc(MESSAGE_ACTION_ERROR,
+                            MessageFormat.format("Unable to perform action: {0}.", ex.getMessage())), HttpStatus.CONFLICT
+            );
+        }
+    }
+
+    // restartMessage, return OK ResponseEntity
+    private ResponseEntity restartMessage(Long id, boolean totalRestart) {
+        messageOperationService.restartMessage(id, totalRestart);
+        return new ResponseEntity<>(
+                new ActionResultRpc(MESSAGE_ACTION_OK, "Successful message restart."), HttpStatus.OK);
+    }
 }

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rest/MessageController.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rest/MessageController.java
@@ -1,0 +1,94 @@
+package org.openhubframework.openhub.admin.web.message.rest;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.openhubframework.openhub.admin.web.common.AbstractOhfController;
+import org.openhubframework.openhub.admin.web.message.rpc.MessageFilterRpc;
+import org.openhubframework.openhub.admin.web.message.rpc.MessageCollectionWrapper;
+import org.openhubframework.openhub.admin.web.message.rpc.MessageListItemRpc;
+import org.openhubframework.openhub.admin.web.message.rpc.MessageRpc;
+import org.openhubframework.openhub.api.common.Constraints;
+import org.openhubframework.openhub.api.configuration.ConfigurableValue;
+import org.openhubframework.openhub.api.configuration.ConfigurationItem;
+import org.openhubframework.openhub.api.entity.Message;
+import org.openhubframework.openhub.api.entity.MessageFilter;
+import org.openhubframework.openhub.common.OpenHubPropertyConstants;
+import org.openhubframework.openhub.spi.msg.MessageService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for managing operation with messages.
+ *
+ * @author Karel Kovarik
+ */
+@RestController
+@RequestMapping(value = MessageController.REST_URI)
+public class MessageController extends AbstractOhfController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MessageController.class);
+
+    public static final String REST_URI = BASE_PATH + "/messages";
+
+    private static final String MESSAGES_LIMIT_PROPERTY = OpenHubPropertyConstants.PREFIX + "admin.console.messages.limit";
+
+    @ConfigurableValue(key = MESSAGES_LIMIT_PROPERTY)
+    private ConfigurationItem<Long> messagesLimit;
+
+    @Autowired
+    private MessageService messageService;
+
+    /**
+     * List messages, by given filter.
+     * @param messageFilter the filter to filter messages.
+     * @return custom collection wrapper with messagelist elemenets.
+     */
+    @GetMapping(produces = {"application/xml", "application/json"})
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public MessageCollectionWrapper<MessageListItemRpc> list(final MessageFilterRpc messageFilter){
+        Constraints.notNull(messageFilter.getReceivedFrom(), "The receivedFrom is mandatory.");
+
+        final MessageFilter filter =
+                MessageFilterRpc.toMessageFilter().convert(messageFilter);
+        LOG.trace("List messages by filter [{}].", filter);
+
+        // fetch messages from messageService
+        final List<Message> messageList = messageService.findMessagesByFilter(filter);
+
+        return new MessageCollectionWrapper<>(
+                MessageListItemRpc.fromMessage(),
+                messageList,
+                messagesLimit.getValue(0L),
+                messageList.size()
+        );
+    }
+
+    /**
+     * Get detail of message identified by its id.
+     * @param id the id of message.
+     * @return message detail.
+     */
+    @GetMapping(path = "/{id}", produces = {"application/xml", "application/json"})
+    public ResponseEntity<MessageRpc> detail(@PathVariable final Long id) {
+        LOG.trace("Fetch detail of message with id [{}].", id);
+
+        return Optional.ofNullable(messageService.findEagerMessageById(id))
+                .map(message -> new ResponseEntity<>(
+                        MessageRpc.fromMessage().convert(message), HttpStatus.OK)
+                )
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    // action TBA
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ActionRequestRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ActionRequestRpc.java
@@ -16,32 +16,50 @@
 
 package org.openhubframework.openhub.admin.web.message.rpc;
 
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.openhubframework.openhub.api.entity.Message;
-import org.springframework.core.convert.converter.Converter;
+import org.springframework.validation.annotation.Validated;
 
 
 /**
- * Message list item RPC, only subset of message attributes are used.
+ * Request rpc for action with message.
  *
  * @author Karel Kovarik
  * @since 2.0
  */
-public class MessageListItemRpc extends MessageBaseRpc {
+@Validated
+public class ActionRequestRpc {
 
-    /**
-     * Convert MessageListRpc from Message entity.
-     * @return filled in rpc object.
-     */
-    public static Converter<Message, MessageListItemRpc> fromMessage() {
-        return source -> fromMessage(new MessageListItemRpc()).convert(source);
+    public static final String TOTAL_RESTART_FIELD = "totalRestart";
+
+    @NotNull
+    private ActionTypeRpc type;
+    private JsonNode data;
+
+    public ActionTypeRpc getType() {
+        return type;
+    }
+
+    public void setType(ActionTypeRpc type) {
+        this.type = type;
+    }
+
+    public JsonNode getData() {
+        return data;
+    }
+
+    public void setData(JsonNode data) {
+        this.data = data;
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-                .appendSuper(super.toString())
+                .append("type", type)
+                .append("data", data)
                 .toString();
     }
 }

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ActionResultRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ActionResultRpc.java
@@ -18,30 +18,36 @@ package org.openhubframework.openhub.admin.web.message.rpc;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.openhubframework.openhub.api.entity.Message;
-import org.springframework.core.convert.converter.Converter;
 
 
 /**
- * Message list item RPC, only subset of message attributes are used.
+ * Action result rpc object.
  *
  * @author Karel Kovarik
  * @since 2.0
  */
-public class MessageListItemRpc extends MessageBaseRpc {
+public class ActionResultRpc {
+    private final String result;
+    private final String resultDescription;
 
-    /**
-     * Convert MessageListRpc from Message entity.
-     * @return filled in rpc object.
-     */
-    public static Converter<Message, MessageListItemRpc> fromMessage() {
-        return source -> fromMessage(new MessageListItemRpc()).convert(source);
+    public ActionResultRpc(String result, String resultDescription) {
+        this.result = result;
+        this.resultDescription = resultDescription;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public String getResultDescription() {
+        return resultDescription;
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
-                .appendSuper(super.toString())
+                .append("result", result)
+                .append("resultDescription", resultDescription)
                 .toString();
     }
 }

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ActionTypeRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ActionTypeRpc.java
@@ -1,0 +1,11 @@
+package org.openhubframework.openhub.admin.web.message.rpc;
+
+/**
+ * Rpc for action possible to perform with message.
+ *
+ * @author Karel Kovarik
+ */
+public enum ActionTypeRpc {
+    RESTART,
+    CANCEL
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ExternalCallInfoRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ExternalCallInfoRpc.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openhubframework.openhub.admin.web.message.rpc;
 
 import java.time.ZoneId;
@@ -15,6 +31,7 @@ import org.springframework.core.convert.converter.Converter;
  * ExternalCall related to the message.
  *
  * @author Karel Kovarik
+ * @since 2.0
  */
 public class ExternalCallInfoRpc extends BaseRpc<ExternalCall, Long> {
 

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ExternalCallInfoRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ExternalCallInfoRpc.java
@@ -1,0 +1,81 @@
+package org.openhubframework.openhub.admin.web.message.rpc;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openhubframework.openhub.admin.web.common.rpc.BaseRpc;
+import org.openhubframework.openhub.api.entity.ExternalCall;
+import org.openhubframework.openhub.api.entity.ExternalCallStateEnum;
+import org.springframework.core.convert.converter.Converter;
+
+
+/**
+ * ExternalCall related to the message.
+ *
+ * @author Karel Kovarik
+ */
+public class ExternalCallInfoRpc extends BaseRpc<ExternalCall, Long> {
+
+    private ExternalCallStateEnum state;
+    private String operationName;
+    private String callId;
+    private ZonedDateTime lastChange;
+
+    public ExternalCallStateEnum getState() {
+        return state;
+    }
+
+    public void setState(ExternalCallStateEnum state) {
+        this.state = state;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
+    }
+
+    public String getCallId() {
+        return callId;
+    }
+
+    public void setCallId(String callId) {
+        this.callId = callId;
+    }
+
+    public ZonedDateTime getLastChange() {
+        return lastChange;
+    }
+
+    public void setLastChange(ZonedDateTime lastChange) {
+        this.lastChange = lastChange;
+    }
+
+    public static Converter<ExternalCall, ExternalCallInfoRpc> fromExternalCall() {
+        return source -> {
+            final ExternalCallInfoRpc ret = new ExternalCallInfoRpc();
+            ret.setId(source.getId());
+            ret.setState(source.getState());
+            ret.setOperationName(source.getOperationName());
+            ret.setCallId(source.getEntityId());
+            ret.setLastChange(ZonedDateTime.ofInstant(source.getLastUpdateTimestamp(), ZoneId.systemDefault()));
+            return ret;
+        };
+    }
+
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .appendSuper(super.toString())
+                .append("state", state)
+                .append("operationName", operationName)
+                .append("callId", callId)
+                .append("lastChange", lastChange)
+                .toString();
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageBaseRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageBaseRpc.java
@@ -1,0 +1,131 @@
+package org.openhubframework.openhub.admin.web.message.rpc;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openhubframework.openhub.admin.web.common.rpc.BaseRpc;
+import org.openhubframework.openhub.api.entity.ExternalSystemExtEnum;
+import org.openhubframework.openhub.api.entity.Message;
+import org.openhubframework.openhub.api.entity.MsgStateEnum;
+import org.openhubframework.openhub.api.entity.ServiceExtEnum;
+import org.openhubframework.openhub.api.exception.ErrorExtEnum;
+import org.springframework.core.convert.converter.Converter;
+
+
+/**
+ * Base RPC for message entities.
+ *
+ * @author Karel Kovarik
+ * @see Message entity.
+ */
+public abstract class MessageBaseRpc extends BaseRpc<Message, Long> {
+
+    private String correlationId;
+    private ExternalSystemExtEnum sourceSystem;
+    private ZonedDateTime received;
+    private ZonedDateTime processingStarted;
+    private MsgStateEnum state;
+    private ErrorExtEnum errorCode;
+    private ServiceExtEnum serviceName;
+    private String operationName;
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+    public ExternalSystemExtEnum getSourceSystem() {
+        return sourceSystem;
+    }
+
+    public void setSourceSystem(ExternalSystemExtEnum sourceSystem) {
+        this.sourceSystem = sourceSystem;
+    }
+
+    public ZonedDateTime getReceived() {
+        return received;
+    }
+
+    public void setReceived(ZonedDateTime received) {
+        this.received = received;
+    }
+
+    public ZonedDateTime getProcessingStarted() {
+        return processingStarted;
+    }
+
+    public void setProcessingStarted(ZonedDateTime processingStarted) {
+        this.processingStarted = processingStarted;
+    }
+
+    public MsgStateEnum getState() {
+        return state;
+    }
+
+    public void setState(MsgStateEnum state) {
+        this.state = state;
+    }
+
+    public ErrorExtEnum getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(ErrorExtEnum errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public ServiceExtEnum getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(ServiceExtEnum serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
+    }
+
+    protected static <P extends MessageBaseRpc> Converter<Message, P> fromMessage(P message) {
+        return source -> {
+            message.setId(source.getId());
+            message.setCorrelationId(source.getCorrelationId());
+            message.setSourceSystem(source.getSourceSystem());
+            message.setReceived(
+                    ZonedDateTime.ofInstant(source.getReceiveTimestamp(), ZoneId.systemDefault()));
+            if(source.getStartProcessTimestamp() != null) {
+                message.setProcessingStarted(
+                        ZonedDateTime.ofInstant(source.getStartProcessTimestamp(), ZoneId.systemDefault()));
+            }
+            message.setState(source.getState());
+            message.setErrorCode(source.getFailedErrorCode());
+            message.setServiceName(source.getService());
+            message.setOperationName(source.getOperationName());
+            return message;
+        };
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .appendSuper(super.toString())
+                .append("correlationId", correlationId)
+                .append("sourceSystem", sourceSystem)
+                .append("received", received)
+                .append("processingStarted", processingStarted)
+                .append("state", state)
+                .append("errorCode", errorCode)
+                .append("serviceName", serviceName)
+                .append("operationName", operationName)
+                .toString();
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageBaseRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageBaseRpc.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openhubframework.openhub.admin.web.message.rpc;
 
 import java.time.ZoneId;
@@ -18,6 +34,7 @@ import org.springframework.core.convert.converter.Converter;
  * Base RPC for message entities.
  *
  * @author Karel Kovarik
+ * @since 2.0
  * @see Message entity.
  */
 public abstract class MessageBaseRpc extends BaseRpc<Message, Long> {

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageCollectionWrapper.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageCollectionWrapper.java
@@ -1,0 +1,44 @@
+package org.openhubframework.openhub.admin.web.message.rpc;
+
+import java.util.List;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openhubframework.openhub.admin.web.common.rpc.CollectionWrapper;
+import org.springframework.core.convert.converter.Converter;
+
+
+/**
+ * Messages specific extension of collection wrapper.
+ *
+ * @author Karel Kovarik
+ * @see CollectionWrapper
+ */
+public class MessageCollectionWrapper<T> extends CollectionWrapper<T> {
+
+    private long limit;
+    private long totalElements;
+
+    public <S> MessageCollectionWrapper(Converter<? super S, ? extends T> converter, List<S> data, long limit, long totalElements) {
+        super(converter, data);
+        this.limit = limit;
+        this.totalElements = totalElements;
+    }
+
+    public long getLimit() {
+        return limit;
+    }
+
+    public long getTotalElements() {
+        return totalElements;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .appendSuper(super.toString())
+                .append("limit", limit)
+                .append("totalElements", totalElements)
+                .toString();
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageCollectionWrapper.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageCollectionWrapper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openhubframework.openhub.admin.web.message.rpc;
 
 import java.util.List;
@@ -12,14 +28,15 @@ import org.springframework.core.convert.converter.Converter;
  * Messages specific extension of collection wrapper.
  *
  * @author Karel Kovarik
+ * @since 2.0
  * @see CollectionWrapper
  */
-public class MessageCollectionWrapper<T> extends CollectionWrapper<T> {
+public class MessageCollectionWrapper extends CollectionWrapper<MessageListItemRpc> {
 
     private long limit;
     private long totalElements;
 
-    public <S> MessageCollectionWrapper(Converter<? super S, ? extends T> converter, List<S> data, long limit, long totalElements) {
+    public <S> MessageCollectionWrapper(Converter<? super S, MessageListItemRpc> converter, List<S> data, long limit, long totalElements) {
         super(converter, data);
         this.limit = limit;
         this.totalElements = totalElements;

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageFilterRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageFilterRpc.java
@@ -1,0 +1,178 @@
+package org.openhubframework.openhub.admin.web.message.rpc;
+
+import java.time.OffsetDateTime;
+
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openhubframework.openhub.api.entity.MessageFilter;
+import org.openhubframework.openhub.api.entity.MsgStateEnum;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+/**
+ * Message filter rpc object.
+ * 
+ * @author Karel Kovarik
+ */
+public class MessageFilterRpc {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private OffsetDateTime receivedFrom;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private OffsetDateTime receivedTo;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private OffsetDateTime lastChangeFrom;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private OffsetDateTime lastChangeTo;
+    private String sourceSystem;
+    private String correlationId;
+    private String processId;
+    private MsgStateEnum state;
+    private String errorCode;
+    private String serviceName;
+    private String operationName;
+    private String fulltext;
+
+    public OffsetDateTime getReceivedFrom() {
+        return receivedFrom;
+    }
+
+    public void setReceivedFrom(OffsetDateTime receivedFrom) {
+        this.receivedFrom = receivedFrom;
+    }
+
+    public OffsetDateTime getReceivedTo() {
+        return receivedTo;
+    }
+
+    public void setReceivedTo(OffsetDateTime receivedTo) {
+        this.receivedTo = receivedTo;
+    }
+
+    public OffsetDateTime getLastChangeFrom() {
+        return lastChangeFrom;
+    }
+
+    public void setLastChangeFrom(OffsetDateTime lastChangeFrom) {
+        this.lastChangeFrom = lastChangeFrom;
+    }
+
+    public OffsetDateTime getLastChangeTo() {
+        return lastChangeTo;
+    }
+
+    public void setLastChangeTo(OffsetDateTime lastChangeTo) {
+        this.lastChangeTo = lastChangeTo;
+    }
+
+    public String getSourceSystem() {
+        return sourceSystem;
+    }
+
+    public void setSourceSystem(String sourceSystem) {
+        this.sourceSystem = sourceSystem;
+    }
+
+    public String getCorrelationId() {
+        return correlationId;
+    }
+
+    public void setCorrelationId(String correlationId) {
+        this.correlationId = correlationId;
+    }
+
+    public String getProcessId() {
+        return processId;
+    }
+
+    public void setProcessId(String processId) {
+        this.processId = processId;
+    }
+
+    public MsgStateEnum getState() {
+        return state;
+    }
+
+    public void setState(MsgStateEnum state) {
+        this.state = state;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+
+    public void setOperationName(String operationName) {
+        this.operationName = operationName;
+    }
+
+    public String getFulltext() {
+        return fulltext;
+    }
+
+    public void setFulltext(String fulltext) {
+        this.fulltext = fulltext;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .append("receivedFrom", receivedFrom)
+                .append("receivedTo", receivedTo)
+                .append("lastChangeFrom", lastChangeFrom)
+                .append("lastChangeTo", lastChangeTo)
+                .append("sourceSystem", sourceSystem)
+                .append("correlationId", correlationId)
+                .append("processId", processId)
+                .append("state", state)
+                .append("errorCode", errorCode)
+                .append("serviceName", serviceName)
+                .append("operationName", operationName)
+                .append("fulltext", fulltext)
+                .toString();
+    }
+
+    public static Converter<MessageFilterRpc, MessageFilter> toMessageFilter() {
+        return source -> {
+            final MessageFilter ret = new MessageFilter();
+            if(source.getReceivedFrom() != null) {
+                ret.setReceivedFrom(source.getReceivedFrom().toInstant());
+            }
+            if(source.getReceivedTo() != null) {
+                ret.setReceivedTo(source.getReceivedTo().toInstant());
+            }
+            if(source.getLastChangeFrom() != null) {
+                ret.setLastChangeFrom(source.getLastChangeFrom().toInstant());
+            }
+            if(source.getLastChangeTo() != null) {
+                ret.setLastChangeTo(source.getLastChangeTo().toInstant());
+            }
+            ret.setSourceSystem(source.getSourceSystem());
+            ret.setCorrelationId(source.getCorrelationId());
+            ret.setProcessId(source.getProcessId());
+            ret.setState(source.getState());
+            ret.setErrorCode(source.getErrorCode());
+            ret.setServiceName(source.getServiceName());
+            ret.setOperationName(source.getOperationName());
+            ret.setFulltext(source.getFulltext());
+            return ret;
+        };
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageFilterRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageFilterRpc.java
@@ -1,8 +1,22 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openhubframework.openhub.admin.web.message.rpc;
 
 import java.time.OffsetDateTime;
-
-import javax.validation.constraints.NotNull;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -13,11 +27,13 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 /**
  * Message filter rpc object.
- * 
+ *
  * @author Karel Kovarik
+ * @since 2.0
  */
 public class MessageFilterRpc {
 
+    //TODO (kkovarik, 15.7.2017, TASK) setup global jackson binding, iso format to be default
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private OffsetDateTime receivedFrom;
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageListItemRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageListItemRpc.java
@@ -1,0 +1,30 @@
+package org.openhubframework.openhub.admin.web.message.rpc;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openhubframework.openhub.api.entity.Message;
+import org.springframework.core.convert.converter.Converter;
+
+
+/**
+ * Message list item RPC, only subset of message attributes are used.
+ *
+ * @author Karel Kovarik
+ */
+public class MessageListItemRpc extends MessageBaseRpc {
+
+    /**
+     * Convert MessageListRpc from Message entity.
+     * @return filled in rpc object.
+     */
+    public static Converter<Message, MessageListItemRpc> fromMessage() {
+        return source -> fromMessage(new MessageListItemRpc()).convert(source);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .appendSuper(super.toString())
+                .toString();
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageRpc.java
@@ -1,0 +1,254 @@
+package org.openhubframework.openhub.admin.web.message.rpc;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openhubframework.openhub.api.entity.EntityTypeExtEnum;
+import org.openhubframework.openhub.api.entity.Message;
+import org.openhubframework.openhub.api.entity.MessageActionType;
+import org.openhubframework.openhub.core.common.asynch.msg.MessageHelper;
+import org.springframework.core.convert.converter.Converter;
+
+
+/**
+ * Message detail RPC, with all attributes for detail queries.
+ *
+ * @author Karel Kovarik
+ */
+public class MessageRpc extends MessageBaseRpc {
+
+    private String processId;
+    private ZonedDateTime lastChange;
+    private int failedCount;
+    private ZonedDateTime msgTimestamp;
+    private String objectId;
+    private EntityTypeExtEnum entityType;
+    private String funnelValue;
+    private String funnelComponentId;
+    private boolean guaranteedOrder;
+    private boolean excludeFailedState;
+    private String businessError;
+    private Long parentMsgId;
+    private String body;
+    private String envelope;
+    private String failedDescription;
+    private List<RequestInfoRpc> requests;
+    private List<ExternalCallInfoRpc> externalCalls;
+    private List<MessageActionType> allowedActions;
+
+    public String getProcessId() {
+        return processId;
+    }
+
+    public void setProcessId(String processId) {
+        this.processId = processId;
+    }
+
+    public ZonedDateTime getLastChange() {
+        return lastChange;
+    }
+
+    public void setLastChange(ZonedDateTime lastChange) {
+        this.lastChange = lastChange;
+    }
+
+    public int getFailedCount() {
+        return failedCount;
+    }
+
+    public void setFailedCount(int failedCount) {
+        this.failedCount = failedCount;
+    }
+
+    public ZonedDateTime getMsgTimestamp() {
+        return msgTimestamp;
+    }
+
+    public void setMsgTimestamp(ZonedDateTime msgTimestamp) {
+        this.msgTimestamp = msgTimestamp;
+    }
+
+    public String getObjectId() {
+        return objectId;
+    }
+
+    public void setObjectId(String objectId) {
+        this.objectId = objectId;
+    }
+
+    public EntityTypeExtEnum getEntityType() {
+        return entityType;
+    }
+
+    public void setEntityType(EntityTypeExtEnum entityType) {
+        this.entityType = entityType;
+    }
+
+    public String getFunnelValue() {
+        return funnelValue;
+    }
+
+    public void setFunnelValue(String funnelValue) {
+        this.funnelValue = funnelValue;
+    }
+
+    public String getFunnelComponentId() {
+        return funnelComponentId;
+    }
+
+    public void setFunnelComponentId(String funnelComponentId) {
+        this.funnelComponentId = funnelComponentId;
+    }
+
+    public boolean isGuaranteedOrder() {
+        return guaranteedOrder;
+    }
+
+    public void setGuaranteedOrder(boolean guaranteedOrder) {
+        this.guaranteedOrder = guaranteedOrder;
+    }
+
+    public boolean isExcludeFailedState() {
+        return excludeFailedState;
+    }
+
+    public void setExcludeFailedState(boolean excludeFailedState) {
+        this.excludeFailedState = excludeFailedState;
+    }
+
+    public String getBusinessError() {
+        return businessError;
+    }
+
+    public void setBusinessError(String businessError) {
+        this.businessError = businessError;
+    }
+
+    public Long getParentMsgId() {
+        return parentMsgId;
+    }
+
+    public void setParentMsgId(Long parentMsgId) {
+        this.parentMsgId = parentMsgId;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public String getEnvelope() {
+        return envelope;
+    }
+
+    public void setEnvelope(String envelope) {
+        this.envelope = envelope;
+    }
+
+    public String getFailedDescription() {
+        return failedDescription;
+    }
+
+    public void setFailedDescription(String failedDescription) {
+        this.failedDescription = failedDescription;
+    }
+
+    public List<RequestInfoRpc> getRequests() {
+        return requests;
+    }
+
+    public void setRequests(List<RequestInfoRpc> requests) {
+        this.requests = requests;
+    }
+
+    public List<ExternalCallInfoRpc> getExternalCalls() {
+        return externalCalls;
+    }
+
+    public void setExternalCalls(List<ExternalCallInfoRpc> externalCalls) {
+        this.externalCalls = externalCalls;
+    }
+
+    public List<MessageActionType> getAllowedActions() {
+        return allowedActions;
+    }
+
+    public void setAllowedActions(List<MessageActionType> allowedActions) {
+        this.allowedActions = allowedActions;
+    }
+
+    /**
+     * Converter to convert from Message entity.
+     * @return filled in MessageRpc object.
+     */
+    public static Converter<Message, MessageRpc> fromMessage() {
+        return source -> {
+            final MessageRpc ret = fromMessage(new MessageRpc()).convert(source);
+            // additional fields
+            ret.setProcessId(source.getProcessId());
+            if(source.getLastUpdateTimestamp() != null) {
+                ret.setLastChange(
+                        ZonedDateTime.ofInstant(source.getLastUpdateTimestamp(), ZoneId.systemDefault())
+                );
+            }
+            ret.setFailedCount(source.getFailedCount());
+            if(source.getMsgTimestamp() != null) {
+                ret.setMsgTimestamp(
+                        ZonedDateTime.ofInstant(source.getMsgTimestamp(), ZoneId.systemDefault())
+                );
+            }
+            ret.setObjectId(source.getObjectId());
+            ret.setEntityType(source.getEntityType());
+            ret.setFunnelValue(source.getFunnelValue());
+            ret.setFunnelComponentId(source.getFunnelComponentId());
+            ret.setGuaranteedOrder(source.isGuaranteedOrder());
+            ret.setExcludeFailedState(source.isExcludeFailedState());
+            ret.setBusinessError(source.getBusinessError());
+            ret.setParentMsgId(source.getParentMsgId());
+            ret.setBody(source.getPayload());
+            ret.setEnvelope(source.getEnvelope());
+            ret.setFailedDescription(source.getFailedDesc());
+            ret.setRequests(source.getRequests().stream()
+                    .map(request -> RequestInfoRpc.fromRequest().convert(request))
+                    .collect(Collectors.toList())
+            );
+            ret.setExternalCalls(source.getExternalCalls().stream()
+                    .map(externalCall -> ExternalCallInfoRpc.fromExternalCall().convert(externalCall))
+                    .collect(Collectors.toList())
+            );
+            ret.setAllowedActions(MessageHelper.allowedActions(source));
+            return ret;
+        };
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .appendSuper(super.toString())
+                .append("processId", processId)
+                .append("lastChange", lastChange)
+                .append("failedCount", failedCount)
+                .append("msgTimestamp", msgTimestamp)
+                .append("objectId", objectId)
+                .append("entityType", entityType)
+                .append("funnelValue", funnelValue)
+                .append("funnelComponentId", funnelComponentId)
+                .append("guaranteedOrder", guaranteedOrder)
+                .append("excludeFailedState", excludeFailedState)
+                .append("businessError", businessError)
+                .append("parentMsgId", parentMsgId)
+                // body skipped
+                // envelope skipped
+                .append("failedDescription", failedDescription)
+                .append("requests", requests)
+                .append("externalCalls", externalCalls)
+                .toString();
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/MessageRpc.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openhubframework.openhub.admin.web.message.rpc;
 
 import java.time.ZoneId;
@@ -18,6 +34,7 @@ import org.springframework.core.convert.converter.Converter;
  * Message detail RPC, with all attributes for detail queries.
  *
  * @author Karel Kovarik
+ * @since 2.0
  */
 public class MessageRpc extends MessageBaseRpc {
 

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/RequestInfoRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/RequestInfoRpc.java
@@ -1,0 +1,81 @@
+package org.openhubframework.openhub.admin.web.message.rpc;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openhubframework.openhub.admin.web.common.rpc.BaseRpc;
+import org.openhubframework.openhub.api.entity.Request;
+import org.springframework.core.convert.converter.Converter;
+
+
+/**
+ * Request related to the message.
+ *
+ * @author Karel Kovarik
+ */
+public class RequestInfoRpc extends BaseRpc<Request, Long> {
+
+    private String uri;
+    private ZonedDateTime timestamp;
+    private String payload;
+    private ResponseInfoRpc response;
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public ZonedDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(ZonedDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public ResponseInfoRpc getResponse() {
+        return response;
+    }
+
+    public void setResponse(ResponseInfoRpc response) {
+        this.response = response;
+    }
+
+    public static Converter<Request, RequestInfoRpc> fromRequest() {
+        return source -> {
+            final RequestInfoRpc ret = new RequestInfoRpc();
+            ret.setId(source.getId());
+            ret.setUri(source.getUri());
+            ret.setTimestamp(ZonedDateTime.ofInstant(source.getReqTimestamp(), ZoneId.systemDefault()));
+            ret.setPayload(source.getRequest());
+            if(source.getResponse() != null) {
+                ret.setResponse(ResponseInfoRpc.fromResponse().convert(source.getResponse()));
+            }
+            return ret;
+        };
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .appendSuper(super.toString())
+                .append("uri", uri)
+                .append("timestamp", timestamp)
+                // no payload
+                .append("response", response)
+                .toString();
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/RequestInfoRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/RequestInfoRpc.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openhubframework.openhub.admin.web.message.rpc;
 
 import java.time.ZoneId;
@@ -14,6 +30,7 @@ import org.springframework.core.convert.converter.Converter;
  * Request related to the message.
  *
  * @author Karel Kovarik
+ * @since 2.0
  */
 public class RequestInfoRpc extends BaseRpc<Request, Long> {
 

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ResponseInfoRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ResponseInfoRpc.java
@@ -1,0 +1,61 @@
+package org.openhubframework.openhub.admin.web.message.rpc;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.openhubframework.openhub.admin.web.common.rpc.BaseRpc;
+import org.openhubframework.openhub.api.entity.Response;
+import org.springframework.core.convert.converter.Converter;
+
+
+/**
+ * Response related to the request.
+ *
+ * @author Karel Kovarik
+ */
+public class ResponseInfoRpc extends BaseRpc<Response, Long> {
+
+    private ZonedDateTime timestamp;
+    private String payload;
+
+    public ZonedDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(ZonedDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public static Converter<Response, ResponseInfoRpc> fromResponse() {
+        return source -> {
+            final ResponseInfoRpc ret = new ResponseInfoRpc();
+            ret.setId(source.getId());
+            if(source.getResTimestamp() != null) {
+                ret.setTimestamp(
+                        ZonedDateTime.ofInstant(source.getResTimestamp(), ZoneId.systemDefault())
+                );
+            }
+            ret.setPayload(source.getResponse());
+            return ret;
+        };
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+                .appendSuper(super.toString())
+                .append("timestamp", timestamp)
+                // no payload
+                .toString();
+    }
+}

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ResponseInfoRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/message/rpc/ResponseInfoRpc.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.openhubframework.openhub.admin.web.message.rpc;
 
 import java.time.ZoneId;
@@ -14,6 +30,7 @@ import org.springframework.core.convert.converter.Converter;
  * Response related to the request.
  *
  * @author Karel Kovarik
+ * @since 2.0
  */
 public class ResponseInfoRpc extends BaseRpc<Response, Long> {
 

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/msg/MessageController.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/msg/MessageController.java
@@ -47,7 +47,7 @@ import org.openhubframework.openhub.spi.msg.MessageService;
  * @author Petr Juza
  * @author Tomas Hanus
  */
-@Controller
+@Controller("LegacyMessageControler")
 @RequestMapping("/messages")
 public class MessageController {
 

--- a/web-admin/src/main/java/org/openhubframework/openhub/web/common/WebProps.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/web/common/WebProps.java
@@ -14,15 +14,22 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.admin.web.message.rpc;
+package org.openhubframework.openhub.web.common;
+
+import org.openhubframework.openhub.common.OpenHubPropertyConstants;
+
 
 /**
- * Rpc for action possible to perform with message.
+ * Constants of web module related property names.
  *
  * @author Karel Kovarik
  * @since 2.0
  */
-public enum ActionTypeRpc {
-    RESTART,
-    CANCEL
+public final class WebProps {
+
+    public static final String MESSAGES_LIMIT = OpenHubPropertyConstants.PREFIX + "admin.console.messages.limit";
+
+    private WebProps() {
+        // to prevent instantiation
+    }
 }

--- a/web-admin/src/main/resources/application.properties
+++ b/web-admin/src/main/resources/application.properties
@@ -439,3 +439,6 @@ ohf.admin.console.config.menu.external-links.items[0].title = Javamelody Monitor
 ohf.admin.console.config.menu.external-links.items[0].link = ${javamelody.init-parameters.monitoring-path}
 ohf.admin.console.config.menu.external-links.items[0].enabled = ${javamelody.enabled}
 ohf.admin.console.config.menu.changes.enabled = true
+
+# Messages api configuration
+ohf.admin.console.messages.limit = 100

--- a/web-admin/src/test/java/org/openhubframework/openhub/admin/web/message/rest/MessageControllerTest.java
+++ b/web-admin/src/test/java/org/openhubframework/openhub/admin/web/message/rest/MessageControllerTest.java
@@ -1,0 +1,297 @@
+package org.openhubframework.openhub.admin.web.message.rest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.times;
+import static org.openhubframework.openhub.test.rest.TestRestUtils.createGetUrl;
+import static org.openhubframework.openhub.test.rest.TestRestUtils.toUrl;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.openhubframework.openhub.admin.AbstractAdminModuleRestTest;
+import org.openhubframework.openhub.api.entity.ExternalCall;
+import org.openhubframework.openhub.api.entity.ExternalCallStateEnum;
+import org.openhubframework.openhub.api.entity.Message;
+import org.openhubframework.openhub.api.entity.MessageFilter;
+import org.openhubframework.openhub.api.entity.MsgStateEnum;
+import org.openhubframework.openhub.api.entity.Request;
+import org.openhubframework.openhub.spi.msg.MessageService;
+import org.openhubframework.openhub.test.data.EntityTypeTestEnum;
+import org.openhubframework.openhub.test.data.ErrorTestEnum;
+import org.openhubframework.openhub.test.data.ExternalSystemTestEnum;
+import org.openhubframework.openhub.test.data.ServiceTestEnum;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.ReflectionUtils;
+
+
+/**
+ * Simple test suite for {@link MessageController}.
+ *
+ * @author Karel Kovarik
+ */
+@TestPropertySource(properties = {
+        "ohf.admin.console.messages.limit = 42"
+})
+public class MessageControllerTest extends AbstractAdminModuleRestTest {
+
+    private static final String ROOT_URI = MessageController.REST_URI;
+
+    // mocked messageService
+    @MockBean
+    private MessageService messageService;
+
+    @Test
+    public void list_minimalOk() throws Exception {
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI)
+                .addParameter("receivedFrom", "2017-05-28T11:47:28+02:00")
+                ;
+
+        final ArgumentCaptor<MessageFilter> argumentCaptor = ArgumentCaptor.forClass(MessageFilter.class);
+        Mockito.when(messageService.findMessagesByFilter(argumentCaptor.capture()))
+                .thenReturn(Collections.emptyList());
+
+        // GET /api/messages
+        mockMvc.perform(get(toUrl(uriBuilder))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(0)))
+                .andExpect(jsonPath("$.limit", is(42)))
+                .andExpect(jsonPath("$.totalElements", is(0)))
+        ;
+
+        final MessageFilter filter = argumentCaptor.getValue();
+        assertThat(filter.getReceivedFrom(), is(Instant.parse("2017-05-28T09:47:28Z")));
+    }
+
+    @Test
+    public void list_Ok() throws Exception {
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI)
+                .addParameter("receivedFrom", "2017-05-28T11:47:28+02:00")
+                .addParameter("receivedTo", "2017-05-30T11:47:28+02:00")
+                .addParameter("lastChangeFrom", "2017-04-30T11:47:28+02:00")
+                .addParameter("lastChangeTo", "2017-06-30T11:47:28+02:00")
+                .addParameter("sourceSystem", "CRM")
+                .addParameter("correlationId", "20301-2332-1321")
+                .addParameter("processId", "10231-2311-1144")
+                .addParameter("state", "OK")
+                .addParameter("errorCode", "E114")
+                .addParameter("serviceName", "HELLO")
+                .addParameter("operationName", "check")
+                .addParameter("fulltext", "fulltext-message")
+                ;
+
+        final ZonedDateTime dateTime =
+                LocalDateTime
+                        .of(2017,5,27,19,5,10)
+                        .atZone(ZoneId.systemDefault());
+
+        final Message msg = new Message();
+        msg.setId(84L);
+        msg.setCorrelationId("20301-2332-1321");
+        msg.setProcessId("10231-2311-1144");
+        msg.setState(MsgStateEnum.OK);
+        msg.setStartProcessTimestamp(dateTime.plusMinutes(1).toInstant());
+        msg.setLastUpdateTimestamp(dateTime.plusHours(2).toInstant());
+        msg.setFailedErrorCode(ErrorTestEnum.E300);
+        msg.setFailedCount(3);
+        msg.setSourceSystem(ExternalSystemTestEnum.CRM);
+        msg.setReceiveTimestamp(dateTime.plusHours(1).toInstant());
+        msg.setMsgTimestamp(dateTime.toInstant());
+        msg.setService(ServiceTestEnum.CUSTOMER);
+        msg.setOperationName("setCustomer");
+        msg.setObjectId("customer42");
+        msg.setEntityType(EntityTypeTestEnum.ACCOUNT);
+        msg.setFunnelValue("MSISDN");
+        msg.setFunnelComponentId("componentId");
+        msg.setGuaranteedOrder(Boolean.TRUE);
+        msg.setExcludeFailedState(Boolean.TRUE);
+        msg.setBusinessError("Not enough balance in the account");
+        msg.setParentMsgId(333L);
+        msg.setPayload("<hel:hello>Hello</hel:hello>");
+        msg.setEnvelope("<soap:envelope><hel:hello>Hello</hel:hello></soap:envelope>");
+        msg.setFailedDesc("Something went terribly wrong");
+
+        final ArgumentCaptor<MessageFilter> argumentCaptor = ArgumentCaptor.forClass(MessageFilter.class);
+        Mockito.when(messageService.findMessagesByFilter(argumentCaptor.capture()))
+                .thenReturn(Collections.singletonList(msg));
+
+        // GET /api/messages
+        mockMvc.perform(get(toUrl(uriBuilder))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data", hasSize(1)))
+                .andExpect(jsonPath("$.data[0].id", is(84)))
+                .andExpect(jsonPath("$.data[0].correlationId", is("20301-2332-1321")))
+                .andExpect(jsonPath("$.data[0].sourceSystem", is("CRM")))
+                .andExpect(jsonPath("$.data[0].received", is("2017-05-27T20:05:10+02:00")))
+                .andExpect(jsonPath("$.data[0].processingStarted", is("2017-05-27T19:06:10+02:00")))
+                .andExpect(jsonPath("$.data[0].state", is("OK")))
+                .andExpect(jsonPath("$.data[0].errorCode", is("E300")))
+                .andExpect(jsonPath("$.data[0].serviceName", is("CUSTOMER")))
+                .andExpect(jsonPath("$.data[0].operationName", is("setCustomer")))
+                .andExpect(jsonPath("$.limit", is(42)))
+                .andExpect(jsonPath("$.totalElements", is(1)))
+        ;
+
+        final MessageFilter filter = argumentCaptor.getValue();
+        assertThat(filter.getReceivedFrom(), is(Instant.parse("2017-05-28T09:47:28Z")));
+        assertThat(filter.getReceivedTo(), is(Instant.parse("2017-05-30T09:47:28Z")));
+        assertThat(filter.getLastChangeFrom(), is(Instant.parse("2017-04-30T09:47:28Z")));
+        assertThat(filter.getLastChangeTo(), is(Instant.parse("2017-06-30T09:47:28Z")));
+        assertThat(filter.getSourceSystem(), is("CRM"));
+        assertThat(filter.getCorrelationId(), is("20301-2332-1321"));
+        assertThat(filter.getProcessId(), is("10231-2311-1144"));
+        assertThat(filter.getState(), is(MsgStateEnum.OK));
+        assertThat(filter.getErrorCode(), is("E114"));
+        assertThat(filter.getServiceName(), is("HELLO"));
+        assertThat(filter.getOperationName(), is("check"));
+        assertThat(filter.getFulltext(), is("fulltext-message"));
+    }
+
+    @Test
+    public void list_badRequest_receivedFrom() throws Exception {
+        final URIBuilder uriBuilder = createGetUrl(ROOT_URI)
+                // without mandatory receivedFrom field
+                ;
+
+        // GET /api/messages
+        mockMvc.perform(get(toUrl(uriBuilder))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isBadRequest())
+        ;
+    }
+
+    @Test
+    public void detail_ok() throws Exception {
+        final ZonedDateTime zdt =
+                LocalDateTime
+                        .of(2017,5,27,19,5,10)
+                        .atZone(ZoneId.systemDefault());
+
+        final Message msg = new Message();
+        msg.setId(42L);
+        msg.setCorrelationId("123-456");
+        msg.setProcessId("789-654");
+        msg.setState(MsgStateEnum.PROCESSING);
+        msg.setStartProcessTimestamp(zdt.plusMinutes(1).toInstant());
+        msg.setLastUpdateTimestamp(zdt.plusHours(2).toInstant());
+        msg.setFailedErrorCode(ErrorTestEnum.E300);
+        msg.setFailedCount(3);
+        msg.setSourceSystem(ExternalSystemTestEnum.CRM);
+        msg.setReceiveTimestamp(zdt.plusHours(1).toInstant());
+        msg.setMsgTimestamp(zdt.toInstant());
+        msg.setService(ServiceTestEnum.CUSTOMER);
+        msg.setOperationName("setCustomer");
+        msg.setObjectId("customer42");
+        msg.setEntityType(EntityTypeTestEnum.ACCOUNT);
+        msg.setFunnelValue("MSISDN");
+        msg.setFunnelComponentId("componentId");
+        msg.setGuaranteedOrder(Boolean.TRUE);
+        msg.setExcludeFailedState(Boolean.TRUE);
+        msg.setBusinessError("Not enough balance in the account");
+        msg.setParentMsgId(333L);
+        msg.setPayload("<hel:hello>Hello</hel:hello>");
+        msg.setEnvelope("<soap:envelope><hel:hello>Hello</hel:hello></soap:envelope>");
+        msg.setFailedDesc("Something went terribly wrong");
+
+        final Request request = new Request();
+        request.setId(421L);
+        request.setUri("spring-ws:http://helloservice.com");
+        request.setReqTimestamp(zdt.minusSeconds(1).toInstant());
+        request.setRequest("request-body");
+
+        final ExternalCall externalCall = new ExternalCall();
+        externalCall.setId(327L);
+        externalCall.setState(ExternalCallStateEnum.OK);
+        externalCall.setOperationName("setCustomerExtCall");
+        externalCall.setLastUpdateTimestamp(zdt.minusSeconds(2).toInstant());
+        externalCall.setEntityId("CRM_4yEW32321");
+
+        final Field field = ReflectionUtils.findField(Message.class, "requests");
+        ReflectionUtils.makeAccessible(field);
+        ReflectionUtils.setField(field, msg, Collections.singleton(request));
+        final Field externalCallField = ReflectionUtils.findField(Message.class, "externalCalls");
+        ReflectionUtils.makeAccessible(externalCallField);
+        ReflectionUtils.setField(externalCallField, msg, Collections.singleton(externalCall));
+
+        Mockito.when(messageService.findEagerMessageById(42L))
+                .thenReturn(msg);
+        // GET /api/messages/{id}
+        mockMvc.perform(get(toUrl(createGetUrl(ROOT_URI + "/42")))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("id", is(42)))
+                .andExpect(jsonPath("correlationId", is("123-456")))
+                .andExpect(jsonPath("processId", is("789-654")))
+                .andExpect(jsonPath("state", is("PROCESSING")))
+                .andExpect(jsonPath("processingStarted", is("2017-05-27T19:06:10+02:00")))
+                .andExpect(jsonPath("lastChange", is("2017-05-27T21:05:10+02:00")))
+                .andExpect(jsonPath("errorCode", is("E300")))
+                .andExpect(jsonPath("failedCount", is(3)))
+                .andExpect(jsonPath("sourceSystem", is("CRM")))
+                .andExpect(jsonPath("received", is("2017-05-27T20:05:10+02:00")))
+                .andExpect(jsonPath("msgTimestamp", is("2017-05-27T19:05:10+02:00")))
+                .andExpect(jsonPath("serviceName", is("CUSTOMER")))
+                .andExpect(jsonPath("operationName", is("setCustomer")))
+                .andExpect(jsonPath("objectId", is("customer42")))
+                .andExpect(jsonPath("entityType", is("ACCOUNT")))
+                .andExpect(jsonPath("funnelValue", is("MSISDN")))
+                .andExpect(jsonPath("funnelComponentId", is("componentId")))
+                .andExpect(jsonPath("guaranteedOrder", is(true)))
+                .andExpect(jsonPath("excludeFailedState", is(true)))
+                .andExpect(jsonPath("businessError", is("Not enough balance in the account")))
+                .andExpect(jsonPath("parentMsgId", is(333)))
+                .andExpect(jsonPath("body", is("<hel:hello>Hello</hel:hello>")))
+                .andExpect(jsonPath("envelope", is("<soap:envelope><hel:hello>Hello</hel:hello></soap:envelope>")))
+                .andExpect(jsonPath("failedDescription", is("Something went terribly wrong")))
+                .andExpect(jsonPath("requests", hasSize(1)))
+                .andExpect(jsonPath("requests[0].id", is(421)))
+                .andExpect(jsonPath("requests[0].uri", is("spring-ws:http://helloservice.com")))
+                .andExpect(jsonPath("requests[0].timestamp", is("2017-05-27T19:05:09+02:00")))
+                .andExpect(jsonPath("requests[0].payload", is("request-body")))
+                .andExpect(jsonPath("externalCalls", hasSize(1)))
+                .andExpect(jsonPath("externalCalls[0].id", is(327)))
+                .andExpect(jsonPath("externalCalls[0].state", is("OK")))
+                .andExpect(jsonPath("externalCalls[0].operationName", is("setCustomerExtCall")))
+                .andExpect(jsonPath("externalCalls[0].callId", is("CRM_4yEW32321")))
+                .andExpect(jsonPath("externalCalls[0].lastChange", is("2017-05-27T19:05:08+02:00")))
+                .andExpect(jsonPath("allowedActions", hasSize(1)))
+                .andExpect(jsonPath("allowedActions[0]", is("CANCEL")))
+        ;
+    }
+
+    @Test
+    public void detail_notFound() throws Exception {
+        Mockito.when(messageService.findEagerMessageById(42L))
+                .thenReturn(null); // not found
+
+        // GET /api/messages/{id}
+        mockMvc.perform(get(toUrl(createGetUrl(ROOT_URI + "/42")))
+                .accept(MediaType.APPLICATION_JSON)
+                .with(SecurityMockMvcRequestPostProcessors.authentication(mockAuthentication("ADMIN"))))
+                .andExpect(status().isNotFound())
+        ;
+
+        Mockito.verify(messageService, times(1)).findEagerMessageById(42L);
+    }
+}


### PR DESCRIPTION
### CHANGES
* added new RestController for messages overview screen:
    * list with filtering - new operation implemented up-down to the dao. There is filter on input, with receivedFrom mandatory field and couple others, that should match with the mockup. Number of results is limited to value in properties.
    * detail - reused MessageService#findEagerMessageById, added available actions, see MessageHelper#allowedActions
    * actions (restart/cancel) - called MessageOperationService. Decision on which action to perform is done directly in the controller. Minor change in MessageOperationService validations, as restarts & cancel can now be done for more states. 
* added two catalogs needed for the overview screen: messageState & sourceSystem
* two commits, one for list & detail, second one for actions.

### MOCKUP
* https://openwise.mybalsamiq.com/projects/openhub/Message%20overview

### API
* http://docs.openhubframework.apiary.io/#reference/0/openhub-messages-overview