### PR TITLE
Support Heroku deploy

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,2 @@
+*.jar
+openhub.war

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java $JAVA_OPTS -Dserver.port=${PORT} -Dspring.profiles.active=example-module,h2 -Dlogging.level.org.hibernate.SQL=warn -jar web-admin/target/openhub-exec.war

--- a/admin-console/package.json
+++ b/admin-console/package.json
@@ -35,7 +35,7 @@
       }
     },
     "dev:mock": {
-      "command": "parallelshell \"npm run mock\" \"npm run dev\"",
+      "command": "parallelshell \"yarn run mock\" \"yarn run dev\"",
       "env": {
         "NODE_ENV": "development",
         "DEBUG": "app:*"
@@ -55,20 +55,20 @@
       }
     },
     "deploy": {
-      "command": "npm run lint && npm run test && npm run clean && npm run compile",
+      "command": "yarn run lint && yarn run test && yarn run clean && yarn run compile",
       "env": {
         "DEBUG": "app:*"
       }
     },
     "deploy:dev": {
-      "command": "npm run deploy",
+      "command": "yarn run deploy",
       "env": {
         "NODE_ENV": "development",
         "DEBUG": "app:*"
       }
     },
     "deploy:prod": {
-      "command": "npm run deploy",
+      "command": "yarn run deploy",
       "env": {
         "NODE_ENV": "production",
         "DEBUG": "app:*"
@@ -91,6 +91,9 @@
   "repository": {
     "type": "",
     "url": ""
+  },
+  "optionalDependencies": {
+    "fsevents": "*"
   },
   "dependencies": {
     "babel-core": "^6.17.0",

--- a/admin-console/pom.xml
+++ b/admin-console/pom.xml
@@ -18,7 +18,7 @@
         <!-- dependency versions-->
         <frontend-plugin-version>1.4</frontend-plugin-version>
         <node-version>v7.2.1</node-version>
-        <yarn-version>v0.16.1</yarn-version>
+        <yarn-version>v0.23.4</yarn-version>
     </properties>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -590,6 +590,7 @@
                             <link>http://www.javadoc.io/doc/org.springframework.ws/spring-ws-core/2.4.0.RELEASE/</link>
                             <link>http://www.javadoc.io/doc/org.springframework/spring-core/4.3.4.RELEASE/</link>
                         </links>
+                        <failOnError>false</failOnError>
                         <aggregate>true</aggregate>
                         <additionalDependencies>
                             <additionalDependency>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,50 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>        
+        </profile>
+
+        <profile>
+            <!-- Heroku deployment -->
+            <!-- See: https://devcenter.heroku.com/articles/slug-compiler -->
+            <id>heroku</id>
+
+            <!-- auto-activation for Heroku -->
+            <activation>
+                <property>
+                    <name>env.DYNO</name>
+                </property>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>2.5</version>
+                        <executions>
+                            <execution>
+                                <id>clean-jar-artifacts</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <configuration>
+                                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>target</directory>
+                                            <includes>
+                                                <include>**/*.jar</include>
+                                                <include>**/openhub.war</include>
+                                            </includes>
+                                        </fileset>
+                                    </filesets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <properties>
@@ -770,7 +813,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>            
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=1.8

--- a/web-admin/pom.xml
+++ b/web-admin/pom.xml
@@ -139,6 +139,14 @@
             <!-- Standalone running -->
             <!-- See: https://openhubframework.atlassian.net/wiki/display/OHF/Standalone+running -->
             <id>esb.executable</id>
+
+            <!-- auto-activation for Heroku -->
+            <activation>
+                <property>
+                    <name>env.DYNO</name>
+                </property>
+            </activation>
+            
             <properties>
                 <packaging.type>executable</packaging.type>
             </properties>


### PR DESCRIPTION
Now it is possible to deploy OpenHub to Heroku. It is necessary to have account on Heroku service and use: `git push heroku feature/heroku-deploy:master -ff --no-verify` from branch, which should be deployed to Heroku.

It is possible to use testable link: https://openhub-dev.herokuapp.com/web/admin/console