### PR TITLE
Config params : improved data types formating

### DIFF
--- a/core-api/src/main/java/org/openhubframework/openhub/api/configuration/DataTypeEnum.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/configuration/DataTypeEnum.java
@@ -21,6 +21,9 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.regex.Pattern;
 
+import org.openhubframework.openhub.common.converter.DataTypeConverter;
+import org.openhubframework.openhub.common.converter.TypeConverterEnum;
+
 
 /**
  * Enumeration of possible data types of configuration parameters.
@@ -33,42 +36,45 @@ public enum DataTypeEnum {
     /**
      * Text, string (default).
      */
-    STRING(String.class),
+    STRING(String.class, TypeConverterEnum.STRING),
 
     /**
      * Integer, whole number.
      */
-    INT(Integer.class),
+    INT(Integer.class, TypeConverterEnum.INT),
 
     /**
      * Floating number.
      */
-    FLOAT(Float.class),
+    FLOAT(Float.class, TypeConverterEnum.FLOAT),
 
     /**
      * Date (without time).
      */
-    DATE(LocalDate.class),
+    DATE(LocalDate.class, TypeConverterEnum.DATE),
 
     /**
      * Boolean.
      */
-    BOOLEAN(Boolean.class),
+    BOOLEAN(Boolean.class, TypeConverterEnum.BOOLEAN),
 
     /**
      * File.
      */
-    FILE(File.class),
+    FILE(File.class, TypeConverterEnum.FILE),
 
     /**
      * Regular pattern.
      */
-    PATTERN(Pattern.class);
+    PATTERN(Pattern.class, TypeConverterEnum.PATTERN);
 
     private Class<?> typeClass;
 
-    DataTypeEnum(Class<?> typeClass) {
+    private DataTypeConverter converter;
+
+    DataTypeEnum(Class<?> typeClass, DataTypeConverter converter) {
         this.typeClass = typeClass;
+        this.converter = converter;
     }
 
     /**
@@ -78,6 +84,15 @@ public enum DataTypeEnum {
      */
     public Class<?> getTypeClass() {
         return typeClass;
+    }
+
+    /**
+     * Gets data type converter.
+     *
+     * @return the DataTypeConverter implementation.
+     */
+    public DataTypeConverter getConverter() {
+        return converter;
     }
 
     /**

--- a/core-api/src/main/java/org/openhubframework/openhub/api/configuration/DbConfigurationParam.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/configuration/DbConfigurationParam.java
@@ -16,6 +16,7 @@
 
 package org.openhubframework.openhub.api.configuration;
 
+import java.text.ParseException;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.Nullable;
 import javax.persistence.*;
@@ -180,6 +181,72 @@ public class DbConfigurationParam extends SuperEntity<String> {
         }
 
         return null;
+    }
+
+    /**
+     * Gets current value converted to the object of appropriate type (integer, boolean etc).
+     *
+     * @return the current raw value.
+     */
+    public Object getCurrentValueAsObject() {
+        try {
+            return getDataType().getConverter().convertToObject(getCurrentValue());
+        } catch (ParseException e) {
+            throw new ConfigurationException(
+                    Tools.fm("Current value '{}' can't be converted to target type {}",
+                            getCurrentValue(), getDataType().name()), getCode());
+        }
+    }
+
+    /**
+     * Sets current value from object of appropriate type directly, it will be converted to string
+     * to be stored in repository.
+     *
+     * @param currentValue the raw object of current value.
+     */
+    public void setCurrentValueAsObject(Object currentValue) {
+        try {
+            setCurrentValue(
+                    getDataType().getConverter().convertToString(currentValue)
+            );
+        } catch (IllegalArgumentException e) {
+            throw new ConfigurationException(
+                    Tools.fm("Current value '{}' can't be converted to target type {}",
+                            currentValue, getDataType().name()), getCode());
+        }
+    }
+
+    /**
+     * Gets default value converted to the object of appropriate type (integer, boolean etc).
+     *
+     * @return the default raw value.
+     */
+    public Object getDefaultValueAsObject() {
+        try {
+            return getDataType().getConverter().convertToObject(getDefaultValue());
+        } catch (ParseException e) {
+            throw new ConfigurationException(
+                    Tools.fm("Default value '{}' can't be converted to target type {}",
+                            getDefaultValue(), getDataType().name()), getCode());
+        }
+    }
+
+    /**
+     * Sets default value from object of appropriate type directly, it will be converted to string
+     * to be stored in repository.
+     *
+     * @param defaultValue the raw object of default value.
+     */
+    public void setDefaultValueAsObject(Object defaultValue) {
+        try {
+            setDefaultValue(
+                    getDataType().getConverter().convertToString(defaultValue)
+            );
+        } catch (IllegalArgumentException e) {
+            throw new ConfigurationException(
+                    Tools.fm("Default value '{}' can't be converted to target type {}",
+                            defaultValue, getDataType().name()), getCode());
+        }
     }
 
     /**

--- a/web-admin/src/main/java/org/openhubframework/openhub/admin/web/configuration/rpc/DbConfigurationParamRpc.java
+++ b/web-admin/src/main/java/org/openhubframework/openhub/admin/web/configuration/rpc/DbConfigurationParamRpc.java
@@ -70,12 +70,12 @@ public class DbConfigurationParamRpc extends ChangeableRpc<DbConfigurationParam,
     /**
      * currentValue: true (string) - current value
      */
-    private String currentValue;
+    private Object currentValue;
 
     /**
      * defaultValue: true (string) - default value (used if current value is not filled)
      */
-    private String defaultValue;
+    private Object defaultValue;
 
     /**
      * dataType (enum[string]): data type of current and default value
@@ -116,8 +116,8 @@ public class DbConfigurationParamRpc extends ChangeableRpc<DbConfigurationParam,
 
         this.code = entity.getCode();
         this.categoryCode = entity.getCategoryCode();
-        this.currentValue = entity.getCurrentValue();
-        this.defaultValue = entity.getDefaultValue();
+        this.currentValue = entity.getCurrentValueAsObject();
+        this.defaultValue = entity.getDefaultValueAsObject();
         this.dataType = entity.getDataType().name();
         this.mandatory = entity.isMandatory();
         this.description = entity.getDescription();
@@ -145,8 +145,8 @@ public class DbConfigurationParamRpc extends ChangeableRpc<DbConfigurationParam,
 
         Assert.isTrue(!created, "Configuration parameter can be updated only");
 
-        param.setCurrentValue(getCurrentValue());
-        param.setDefaultValue(getDefaultValue());
+        param.setCurrentValueAsObject(getCurrentValue());
+        param.setDefaultValueAsObject(getDefaultValue());
         param.setValidationRegEx(getValidationRegEx());
     }
 
@@ -167,20 +167,20 @@ public class DbConfigurationParamRpc extends ChangeableRpc<DbConfigurationParam,
     }
 
     @Nullable
-    public String getCurrentValue() {
+    public Object getCurrentValue() {
         return currentValue;
     }
 
-    public void setCurrentValue(@Nullable String currentValue) {
+    public void setCurrentValue(@Nullable Object currentValue) {
         this.currentValue = currentValue;
     }
 
     @Nullable
-    public String getDefaultValue() {
+    public Object getDefaultValue() {
         return defaultValue;
     }
 
-    public void setDefaultValue(@Nullable String defaultValue) {
+    public void setDefaultValue(@Nullable Object defaultValue) {
         this.defaultValue = defaultValue;
     }
 


### PR DESCRIPTION
### ISSUE
* db params are stored in db as Strings, on RPC the same, therefore when jackson marshalled them they were always with quotes - "true", "42"

### CHANGES
* in DbConfigurationParamRpc, currentValue & defaultValue of param is now java.lang.Object. When DB entity is converted, there is extra manual serialization & deserialization from db entity String.
* DataTypeEnum was extended for each type it now has defined two Functions. one for serialization (Object -> String) other one inverse (String -> Object).
* for example, integer parameter: in DB it is stored still as string, when DB entity is converted to DbConfigurationParamRpc, function Integer.parse() defined in DataTypeEnum is applied