### PR TITLE
Feature/integration test config

### DIFF
--- a/web/src/main/java/org/openhubframework/openhub/web/config/MvcPageableConfiguration.java
+++ b/web/src/main/java/org/openhubframework/openhub/web/config/MvcPageableConfiguration.java
@@ -19,13 +19,13 @@ package org.openhubframework.openhub.web.config;
 import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.data.web.SortHandlerMethodArgumentResolver;
 
 import org.openhubframework.openhub.admin.web.common.rpc.paging.OffsetBasedPagingProperties;
-import org.openhubframework.openhub.common.AutoConfiguration;
-
 
 /**
  * Spring configuration to pageable support.
@@ -34,7 +34,8 @@ import org.openhubframework.openhub.common.AutoConfiguration;
  * @since 2.0
  * @see org.springframework.context.support.PropertySourcesPlaceholderConfigurer
  */
-@AutoConfiguration
+@ConditionalOnWebApplication
+@Configuration
 public class MvcPageableConfiguration {
 
     @Autowired

--- a/web/src/main/resources/META-INF/spring.factories
+++ b/web/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,3 @@
 # Auto Configure
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-	org.openhubframework.openhub.web.config.GlobalSecurityConfig,\
-    org.openhubframework.openhub.web.config.MvcPageableConfiguration
+	org.openhubframework.openhub.web.config.GlobalSecurityConfig

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -41,10 +41,6 @@ logging.level.org.openhubframework.openhub.web.RequestResponseLoggingFilter=DEBU
 # IDENTITY (ContextIdApplicationContextInitializer)
 #spring.application.index= # Application index.
 spring.application.name=${info.app.name}
-# live beans view exposure, supported by /beans actuator
-# see http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/support/LiveBeansView.html
-spring.liveBeansView.mbeanDomain=hierarchy
-
 
 # ===============================
 # = JPA / HIBERNATE

--- a/web/src/test/java/org/openhubframework/openhub/admin/AdminTestConfig.java
+++ b/web/src/test/java/org/openhubframework/openhub/admin/AdminTestConfig.java
@@ -25,7 +25,11 @@ import org.springframework.context.annotation.ComponentScan;
  * @author Petr Juza
  * @since 2.0
  */
-@ComponentScan(basePackages = {"org.openhubframework.openhub.web.common", "org.openhubframework.openhub.admin"})
+@ComponentScan(basePackages = {
+        "org.openhubframework.openhub.web.common",
+        "org.openhubframework.openhub.web.config",
+        "org.openhubframework.openhub.admin"
+})
 public class AdminTestConfig {
 
 }


### PR DESCRIPTION
Changed configuration to enable integration tests, see: https://github.com/OpenWiseSolutions/openhub-ri/pull/1

### CHANGES
* MvcPageableConfiguration removed from spring.factories. Now, when openhub-web module is referenced, this file is picked up and therefore beans from packages like org.openhubframework.openhub.admin are needed or spring context will not start. Switched to "normal" Configuration class.
* ~~added dependency to tomcat to test module, for integration tests to have embedded servlet container ready.~~
* ~~added TestWebConfig class with prepared autoscan for openhub-web beans~~