### PR TITLE
Preparation for candidate release

### DIFF
--- a/admin-console/pom.xml
+++ b/admin-console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openhubframework</groupId>
         <artifactId>openhub</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openhub-admin-console</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.openhubframework</groupId>
         <artifactId>openhub</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openhub-common</artifactId>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openhubframework</groupId>
         <artifactId>openhub</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openhub-components</artifactId>

--- a/core-api/pom.xml
+++ b/core-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openhubframework</groupId>
         <artifactId>openhub</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openhub-core-api</artifactId>

--- a/core-spi/pom.xml
+++ b/core-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openhubframework</groupId>
         <artifactId>openhub</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openhub-core-spi</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openhubframework</groupId>
         <artifactId>openhub</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openhub-core</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openhubframework</groupId>
         <artifactId>openhub</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openhub-examples</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.openhubframework</groupId>
     <artifactId>openhub</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>OpenHub Framework</name>
     <description>OpenHub integration framework</description>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openhubframework</groupId>
         <artifactId>openhub</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openhub-test</artifactId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.openhubframework</groupId>
         <artifactId>openhub</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openhub-war</artifactId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.openhubframework</groupId>
         <artifactId>openhub</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>openhub-web</artifactId>


### PR DESCRIPTION
Actual version of OpenHub is not backward compatible with previous version, we have to increase MAJOR version (http://semver.org/) before releasing. This PR has to be last PR before releasing candidate.

Issue: NOJIRA