### PR TITLE
[OHFJIRA-81] Bugfix: Relative web context

### DIFF
--- a/admin-console/src/services/api.service.js
+++ b/admin-console/src/services/api.service.js
@@ -1,7 +1,7 @@
 import CreateApi from './CreateApi'
 
 const apiService = new CreateApi({
-  base: '/web/admin',
+  base: '../',
   headers: {
     Accept: 'application/json',
     'content-type': 'application/json'

--- a/web/src/main/java/org/openhubframework/openhub/admin/web/services/wsdl/rest/WsdlController.java
+++ b/web/src/main/java/org/openhubframework/openhub/admin/web/services/wsdl/rest/WsdlController.java
@@ -97,6 +97,6 @@ public class WsdlController extends AbstractOhfController {
             throw new RuntimeException("Not valid request.requestURL for parsing:", e);
         }
         final String port = requestURL.getPort() == -1 ? "" : ":" + requestURL.getPort();
-        return requestURL.getProtocol() + "://" + requestURL.getHost() + port;
+        return requestURL.getProtocol() + "://" + requestURL.getHost() + port + request.getContextPath();
     }
 }

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -171,6 +171,7 @@ management.security.roles=${management.security.role}
 javamelody.enabled = true
 # Initialization parameters for JavaMelody (optional)
 #    to change the default "/monitoring" path
+# Note: if you change it, you will probably want to update admin console external link config property accordingly.
 javamelody.init-parameters.monitoring-path = /web/admin/monitoring/javamelody
 
 
@@ -397,7 +398,7 @@ ohf.admin.console.config.menu.configuration.environment.enabled = ${endpoints.en
 ohf.admin.console.config.menu.configuration.error-code-catalog.enabled = true
 ohf.admin.console.config.menu.external-links.enabled = true
 ohf.admin.console.config.menu.external-links.items[0].title = Javamelody Monitoring
-ohf.admin.console.config.menu.external-links.items[0].link = ${javamelody.init-parameters.monitoring-path}
+ohf.admin.console.config.menu.external-links.items[0].link = ../monitoring/javamelody
 ohf.admin.console.config.menu.external-links.items[0].enabled = ${javamelody.enabled}
 ohf.admin.console.config.menu.changes.enabled = true
 


### PR DESCRIPTION
Minor fixes to correctly support relative web context (like default deployment on tomcat, which is on http://<hostname/openhub).

Branch is bugfix only, directly on top of release branch.

#### CHANGES
* admin-console has relative web context instead of absolute one.
* JavaMelody configuration added workaround to support tomcat deployment, as tomcat configures javamelody filter by itsself, so we hook to it and just configure already configured filter.
* WsdlController now adds contextPath to the exposed wsdl URL.
* configuration of admin-console external link to javamelody configured to relative path.

Issue: [OHFJIRA-81](https://openhubframework.atlassian.net/browse/OHFJIRA-81)