### PR TITLE
NOJIRA: RequestSending & ResponseReceive EventNotifiers config

### DIFF
--- a/core/src/test/java/org/openhubframework/openhub/core/reqres/RequestResponseTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/reqres/RequestResponseTest.java
@@ -90,11 +90,11 @@ public class RequestResponseTest extends AbstractCoreDbTest {
     public void prepareConfiguration() {
         setPrivateField(reqSendingEventNotifier, "enable", new FixedConfigurationItem<>(Boolean.TRUE));
         setPrivateField(reqSendingEventNotifier, "endpointFilterPattern",
-                new FixedConfigurationItem<>(java.util.regex.Pattern.compile("^(direct.*target).*$")));
+                java.util.regex.Pattern.compile("^(direct.*target).*$"));
 
         setPrivateField(resReceiveEventNotifier, "enable", new FixedConfigurationItem<>(Boolean.TRUE));
         setPrivateField(resReceiveEventNotifier, "endpointFilterPattern",
-                new FixedConfigurationItem<>(java.util.regex.Pattern.compile("^(direct.*target).*$")));
+                java.util.regex.Pattern.compile("^(direct.*target).*$"));
     }
 
     @Before
@@ -128,10 +128,8 @@ public class RequestResponseTest extends AbstractCoreDbTest {
 
 
         // try it again but change pattern for filtering
-        setPrivateField(reqSendingEventNotifier, "endpointFilterPattern",
-                new FixedConfigurationItem<>(java.util.regex.Pattern.compile("^(noUrl).*$")));
-        setPrivateField(resReceiveEventNotifier, "endpointFilterPattern",
-                new FixedConfigurationItem<>(java.util.regex.Pattern.compile("^(noUrl).*$")));
+        setPrivateField(reqSendingEventNotifier, "endpointFilterPattern", java.util.regex.Pattern.compile("^(noUrl).*$"));
+        setPrivateField(resReceiveEventNotifier, "endpointFilterPattern", java.util.regex.Pattern.compile("^(noUrl).*$"));
 
         producer.sendBody(REQUEST);
 


### PR DESCRIPTION
### ISSUE
* when **ohf.requestSaving.enable** is set to true (and request saving enabled), it does fail on loading the field **ConfigurationItem&lt;Pattern&gt; endpointFilterPattern** as it cannot convert the String from DB to Pattern.
* solved with setting the property as String and compile Pattern afterward "manually".
 _Tried the possibility of adding String -> Pattern converter to Spring ConversionService, however it is not as simple as is seems. I just wanted to register spring converter, to be able to make this conversion. So I said, ok, I will enrich the spring ConversionService bean to support it. Pitfall: Properties from the database are loaded into spring properties. And propertyResolver does use its own ConversionService, not the bean in context.
see: https://github.com/spring-projects/spring-framework/blob/4.3.x/spring-core/src/main/java/org/springframework/core/env/AbstractPropertyResolver.java_

### FOR DISCUSSION
* **do we want the pattern to be always loaded "fresh" in runtime**? even if it means that every time event is intercepted, it will load the property from DB and compile regex.Pattern from it? I was kind of afraid of performance, so I prepared the variant where only once (on startup) the pattern is loaded from DB & compiled.
* Note: Tried to realize this the "standard" way - implementing InitiazingBean or use PostConstruct annotation, however it did not worked. Method was always invoked sooner, than any of DB properties were loaded. Therefore I had to hook this "pattern initialization" to spring event - ApplicationReady, ContextRefreshed worked as well.