### PR TITLE
NOJIRA : improved exception logging in MessageServiceImpl

### DIFF
--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
@@ -40,7 +40,6 @@ import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.Assert;
 
-import org.openhubframework.openhub.api.entity.ExternalSystemExtEnum;
 import org.openhubframework.openhub.api.entity.Message;
 import org.openhubframework.openhub.api.entity.MsgStateEnum;
 import org.openhubframework.openhub.api.entity.Node;
@@ -336,6 +335,7 @@ public class MessageServiceImpl implements MessageService {
                 }
             });
         } catch (DataAccessException ex) {
+            LOG.warn("Caught DataAccessException during setStateInQueueForLock :", ex);
             result = false;
         }
 
@@ -365,6 +365,7 @@ public class MessageServiceImpl implements MessageService {
                 }
             });
         } catch (DataAccessException ex) {
+            LOG.warn("Caught DataAccessException during setStateProcessingForLock :", ex);
             result = false;
         }
 


### PR DESCRIPTION
Minor improvement in logging exceptions in MessageServiceImpl.

### ISSUE
As is, the root cause of exception is lost, not logged, not rethrowed. It just fails with following message:
` CaughtExceptionType: org.openhubframework.openhub.api.exception.LockFailureException, CaughtExceptionMessage: Failed to lock message for change state to 'IN_QUEUE'`. Even when it fails with something entirelly different, like when transactions are not properly configured.

### IMPROVEMENT
Added simple logging in WARN level, not to lose the information entirelly.
