### PR TITLE
admin-console - detail of message without envelope

### DIFF
--- a/admin-console/src/routes/Message/components/Message/Message.js
+++ b/admin-console/src/routes/Message/components/Message/Message.js
@@ -72,7 +72,10 @@ class Message extends Component {
       { t: 'Business error overview', v: message.businessError },
       { t: 'ID of parent message', v: message.parentMsgId },
       { t: 'Content (body) of message', v: <SyntaxHighlighter style={codeStyle} >{message.body}</SyntaxHighlighter > },
-      { t: 'Whole incoming message', v: <SyntaxHighlighter style={codeStyle} >{message.envelope}</SyntaxHighlighter > },
+      { t: 'Whole incoming message',
+        v: <SyntaxHighlighter style={codeStyle} >
+          {(message.envelope !== null && message.envelope !== undefined) ? message.envelope : '-'}
+        </SyntaxHighlighter > },
       { t: 'Custom data', v: message.customData }
     ].map((item) => {
       if (typeof item.v === 'boolean') {


### PR DESCRIPTION
Display detail of message without envelope.
### ISSUE
Envelope is not mandatory on message detail, now detail page fails with error: Uncaught (in promise) Error: Expected `string` for value, got `null`, seems to be issue of the SyntaxHighlighter.

### CHANGE
Do not let null value to be in value for SyntaxHighlighter, replace with "-" instead. 