### PR TITLE
NOJIRA : ConsoleConfigRpc as Component

### DIFF
--- a/web/src/main/java/org/openhubframework/openhub/admin/web/console/rpc/ConsoleConfigRpc.java
+++ b/web/src/main/java/org/openhubframework/openhub/admin/web/console/rpc/ConsoleConfigRpc.java
@@ -18,9 +18,9 @@ package org.openhubframework.openhub.admin.web.console.rpc;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
 import org.openhubframework.openhub.common.OpenHubPropertyConstants;
+import org.springframework.stereotype.Component;
 
 
 /**
@@ -29,7 +29,7 @@ import org.openhubframework.openhub.common.OpenHubPropertyConstants;
  * @author Tomas Hanus
  * @since 2.0
  */
-@Configuration
+@Component
 // actually this object is autodetected via AOP and holds configuration, so we have to serializable only our properties
 @JsonAutoDetect(
         fieldVisibility = JsonAutoDetect.Visibility.NONE,


### PR DESCRIPTION
One line change to solve issue with marshalling ConsoleConfigRpc to JSON using jackson.

### CHANGES
ConsoleConfigRpc is spring Component instead of Configuration. It does not define any beans anyway.

### ISSUE
When jackson-module-jaxb-annotations is on classpath and JaxbAnnotationModule is registered as objectMapper module, ConsoleConfigRpc cannot be marshalled anymore with exception: 
```
2018-06-28 18:08:48 333114 [default task-13] ERROR o.o.o.w.common.ExceptionRestHandler - Common exception posted to client side: GeneralFaultRpc[timestamp=2018-06-28T18:08:48.510+02:00,status=500,error=E100,exception=org.springframework.http.converter.HttpMessageNotWritableException: Could not write content: Direct self-reference leading to cycle (through reference chain: org.openhubframework.openhub.admin.web.console.rpc.ConsoleConfigRpc$$EnhancerBySpringCGLIB$$d158c5a3["$$beanFactory"]->org.springframework.beans.factory.support.DefaultListableBeanFactory["beanClassLoader"]->org.jboss.modules.ModuleClassLoader["module"]->org.jboss.modules.Module["moduleLoader"]->org.jboss.as.server.moduleservice.ServiceModuleLoader["value"]); nested exception is com.fasterxml.jackson.databind.JsonMappingException: Direct self-reference leading to cycle (through reference chain: org.openhubframework.openhub.admin.web.console.rpc.ConsoleConfigRpc$$EnhancerBySpringCGLIB$$d158c5a3["$$beanFactory"]->org.springframework.beans.factory.support.DefaultListableBeanFactory["beanClassLoader"]->org.jboss.modules.ModuleClassLoader["module"]->org.jboss.modules.Module["moduleLoader"]->org.jboss.as.server.moduleservice.ServiceModuleLoader["value"])]
org.springframework.http.converter.HttpMessageNotWritableException: Could not write content: Direct self-reference leading to cycle (through reference chain: org.openhubframework.openhub.admin.web.console.rpc.ConsoleConfigRpc$$EnhancerBySpringCGLIB$$d158c5a3["$$beanFactory"]->org.springframework.beans.factory.support.DefaultListableBeanFactory["beanClassLoader"]->org.jboss.modules.ModuleClassLoader["module"]->org.jboss.modules.Module["moduleLoader"]->org.jboss.as.server.moduleservice.ServiceModuleLoader["value"]); nested exception is com.fasterxml.jackson.databind.JsonMappingException: Direct self-reference leading to cycle (through reference chain: org.openhubframework.openhub.admin.web.console.rpc.ConsoleConfigRpc$$EnhancerBySpringCGLIB$$d158c5a3["$$beanFactory"]->org.springframework.beans.factory.support.DefaultListableBeanFactory["beanClassLoader"]->org.jboss.modules.ModuleClassLoader["module"]->org.jboss.modules.Module["moduleLoader"]->org.jboss.as.server.moduleservice.ServiceModuleLoader["value"])
	at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.writeInternal(AbstractJackson2HttpMessageConverter.java:274)
	at org.springframework.http.converter.AbstractGenericHttpMessageConverter.write(AbstractGenericHttpMessageConverter.java:100)
	at org.springframework.web.servlet.mvc.method.annotation.AbstractMessageConverterMethodProcessor.writeWithMessageConverters(AbstractMessageConverterMethodProcessor.java:232)
	at org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor.handleReturnValue(RequestResponseBodyMethodProcessor.java:173)
	at org.springframework.web.method.support.HandlerMethodReturnValueHandlerComposite.handleReturnValue(HandlerMethodReturnValueHandlerComposite.java:81)
```
Haven´t found the cause - working theory is it has something to do with the way spring proxies the class, maybe the annotation JsonAutoDetect could be lost, just guessing, nevertheless works fine as Component, tested with jackson currently in Openhub (2.8.4), and newer one 2.9.x as well.