### PR TITLE
[OHFJIRA-93] : spring boot version to 1.5.17

### DIFF
--- a/admin-console/src/services/api.service.js
+++ b/admin-console/src/services/api.service.js
@@ -1,7 +1,7 @@
 import CreateApi from './CreateApi'
 
 const apiService = new CreateApi({
-  base: '../',
+  base: '..',
   headers: {
     Accept: 'application/json',
     'content-type': 'application/json'

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.1.RELEASE</version>
+        <version>1.5.17.RELEASE</version>
     </parent>
 
     <licenses>
@@ -194,7 +194,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- OpenHub Spring Boot application -->
-        <spring-boot.version>1.5.1.RELEASE</spring-boot.version>
+        <spring-boot.version>1.5.17.RELEASE</spring-boot.version>
         <start-class>org.openhubframework.openhub.OpenHubApplication</start-class>
 
         <camel-version>2.18.2</camel-version>
@@ -206,7 +206,6 @@
         <javamelody-version>1.65.0</javamelody-version>
         <metrics-version>3.2.0</metrics-version>
         <jolokia-version>1.3.5</jolokia-version>
-        <spring-data-commons.version>1.12.8.RELEASE</spring-data-commons.version>
     </properties>
 
     <dependencyManagement>
@@ -257,6 +256,16 @@
                 <groupId>${project.groupId}</groupId>
                 <artifactId>openhub-web</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <!-- Spring boot dependencies -->
+            <!-- Note: too keep camel integration from overriding spring libraries -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <!-- Apache Camel -->
@@ -355,21 +364,6 @@
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>3.0.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-aspects</artifactId>
-                <version>${spring.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.data</groupId>
-                <artifactId>spring-data-commons</artifactId>
-                <version>${spring-data-commons.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-context-support</artifactId>
-                <version>${spring.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/web/src/main/java/org/openhubframework/openhub/config/WebConfigurer.java
+++ b/web/src/main/java/org/openhubframework/openhub/config/WebConfigurer.java
@@ -116,7 +116,7 @@ public class WebConfigurer {
 
     @ConditionalOnProperty(value = CorsProperties.CORS_ENABLED)
     @Bean
-    public FilterRegistrationBean corsFilter() {
+    public FilterRegistrationBean corsFilterRegistrationBean() {
         // it could be used also as http://docs.spring.io/spring-boot/docs/1.5.2.RELEASE/reference/htmlsingle/#boot-features-cors
         // but filter approach has more options
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();


### PR DESCRIPTION
## Spring boot version to 1.5.17

### Changes
* changed version of spring-boot-parent
* added spring-boot-dependency pom import, as otherwise camel spring integration does fetch older version of specific spring libraries. Like there was spring-context-4.3.4 vs spring-context-support 4.3.6. Now all should match the ones from spring-boot 1.5.17
* removed some unneccesary dependencies in dependencyManagement
* had to rename CORS filter registration bean (https://github.com/nydiarra/springboot-jwt/issues/4, configured in https://github.com/spring-projects/spring-security/blob/master/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CorsConfigurer.java#L83)
* had to fix relative api url in admin-console, to remove double slashes in requests, as Spring Security behaviour has changed, and does handle these requests as insecure (https://github.com/spring-projects/spring-boot/issues/11895)