### PR TITLE
[OHFJIRA-84] : java 11 runtime compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,11 @@
         <javamelody-version>1.65.0</javamelody-version>
         <metrics-version>3.2.0</metrics-version>
         <jolokia-version>1.3.5</jolokia-version>
+        <!-- java ee -->
+        <jaxb.version>2.2.11</jaxb.version>
+        <jaxws.version>2.2.12</jaxws.version>
+        <javax-activation.version>1.2.0</javax-activation.version>
+        <saaj-impl.version>1.4.0</saaj-impl.version>
     </properties>
 
     <dependencyManagement>
@@ -302,6 +307,40 @@
                 <version>1.4.186</version>
             </dependency>
 
+            <!-- Java EE, neccessary for jdk 11 runtime, see OHFJIRA-84 -->
+            <!-- JAXB -->
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <!-- JAX-WS -->
+            <dependency>
+                <groupId>javax.xml.ws</groupId>
+                <artifactId>jaxws-api</artifactId>
+                <version>${jaxws.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.messaging.saaj</groupId>
+                <artifactId>saaj-impl</artifactId>
+                <version>${saaj-impl.version}</version>
+            </dependency>
+            <!-- javax.activation -->
+            <dependency>
+                <groupId>com.sun.activation</groupId>
+                <artifactId>javax.activation</artifactId>
+                <version>${javax-activation.version}</version>
+            </dependency>
 
             <!-- Apache commons -->
             <dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -91,6 +91,40 @@
             <artifactId>janino</artifactId>
         </dependency>
 
+        <!-- Java EE -->
+        <!-- jaxb -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+        <!-- jax-ws -->
+        <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+            <version>${jaxws.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.messaging.saaj</groupId>
+            <artifactId>saaj-impl</artifactId>
+            <version>${saaj-impl.version}</version>
+        </dependency>
+        <!-- javax.activation -->
+        <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>javax.activation</artifactId>
+            <version>${javax-activation.version}</version>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
## Support for JDK 11 runtime

With these added libraries, openhub is able to run with java 11 runtime.

### Details
Main issue with backward compatibility is removal of some Java EE APIs:
https://cr.openjdk.java.net/~iris/se/11/spec/fr/java-se-11-fr-spec/#APIs-removed

these apis were marked as deprecated in java 9, removed entirely in java 11.
https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j

Following dependencies were added, as they are required for openhub library stack:
```
javax.xml.bind:jaxb-api
com.sun.xml.bind:jaxb-core
com.sun.xml.bind:jaxb-impl
javax.xml.ws:jaxws-api
com.sun.xml.messaging.saaj:saaj-impl
com.sun.activation:javax.activation
```
Versions used are the ones used in java 8 runtime (when possible).

### Known issues

#### Warning during spring context startup:
```
matching: class path resource [sp_h2_server.xml]
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.springframework.cglib.core.ReflectUtils$1 (jar:file:/home/app.war!/WEB-INF/lib/spring-core-4.3.20.RELEASE.jar!/) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of org.springframework.cglib.core.ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```
Caused by spring framework, does seem to be warning only, **will be resolved in Spring 5.1** (https://jira.spring.io/browse/SPR-15859). Warning should be resolved with migration to Spring Boot 2.x.