### PR TITLE
[OHFJIRA-98] : registration of TestWsUriBuilder bind to property

### DIFF
--- a/examples/src/test/java/org/openhubframework/openhub/modules/AbstractExampleModuleTest.java
+++ b/examples/src/test/java/org/openhubframework/openhub/modules/AbstractExampleModuleTest.java
@@ -16,6 +16,7 @@
 
 package org.openhubframework.openhub.modules;
 
+import org.openhubframework.openhub.test.route.EnableTestWsUriBuilder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -30,6 +31,7 @@ import org.openhubframework.openhub.test.route.ActiveRoutes;
  *
  * @author Petr Juza
  */
+@EnableTestWsUriBuilder
 @ActiveRoutes(classes = ExceptionTranslationRoute.class)
 @ContextConfiguration(classes = ExampleTestConfig.class)
 @ActiveProfiles(profiles = ExampleProperties.EXAMPLE_PROFILE)

--- a/examples/src/test/java/org/openhubframework/openhub/modules/AbstractExampleModulesDbTest.java
+++ b/examples/src/test/java/org/openhubframework/openhub/modules/AbstractExampleModulesDbTest.java
@@ -16,6 +16,7 @@
 
 package org.openhubframework.openhub.modules;
 
+import org.openhubframework.openhub.test.route.EnableTestWsUriBuilder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -29,6 +30,7 @@ import org.openhubframework.openhub.test.route.ActiveRoutes;
  *
  * @author Petr Juza
  */
+@EnableTestWsUriBuilder
 @ActiveRoutes(classes = ExceptionTranslationRoute.class)
 @ContextConfiguration(classes = ExampleTestConfig.class)
 @ActiveProfiles(profiles = ExampleProperties.EXAMPLE_PROFILE)

--- a/test/src/main/java/org/openhubframework/openhub/test/route/EnableTestWsUriBuilder.java
+++ b/test/src/main/java/org/openhubframework/openhub/test/route/EnableTestWsUriBuilder.java
@@ -1,0 +1,24 @@
+package org.openhubframework.openhub.test.route;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+
+/**
+ * Annotation to enable {@link TestWsUriBuilder} for tests.
+ * Please refer to its javadoc for more info.
+ *
+ * @author Karel Kovarik
+ * @since 2.1.0
+ * @see TestWsUriBuilder
+ */
+@Documented
+@Retention(value = RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.TYPE})
+@Import(TestWsUriBuilderConfiguration.class)
+public @interface EnableTestWsUriBuilder {
+}

--- a/test/src/main/java/org/openhubframework/openhub/test/route/TestWsUriBuilder.java
+++ b/test/src/main/java/org/openhubframework/openhub/test/route/TestWsUriBuilder.java
@@ -19,8 +19,6 @@ package org.openhubframework.openhub.test.route;
 import javax.annotation.Nullable;
 import javax.xml.namespace.QName;
 
-import org.springframework.context.annotation.Primary;
-import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
 import org.openhubframework.openhub.api.route.WebServiceUriBuilder;
@@ -41,8 +39,6 @@ import org.openhubframework.openhub.api.route.WebServiceUriBuilder;
  *
  * @author Petr Juza
  */
-@Component
-@Primary
 public class TestWsUriBuilder implements WebServiceUriBuilder {
 
     public static final String URI_WS_IN = "direct:inWS_";

--- a/test/src/main/java/org/openhubframework/openhub/test/route/TestWsUriBuilderConfiguration.java
+++ b/test/src/main/java/org/openhubframework/openhub/test/route/TestWsUriBuilderConfiguration.java
@@ -1,0 +1,22 @@
+package org.openhubframework.openhub.test.route;
+
+import org.openhubframework.openhub.api.route.WebServiceUriBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+/**
+ * Configuration of {@link TestWsUriBuilder}, should be used indirectly
+ * via annotation {@link EnableTestWsUriBuilder}.
+ *
+ * @author Karel Kovarik
+ * @since 2.1.0
+ * @see EnableTestWsUriBuilder
+ */
+public class TestWsUriBuilderConfiguration {
+
+    @Primary
+    @Bean
+    public WebServiceUriBuilder testWebServiceUriBuilder() {
+        return new TestWsUriBuilder();
+    }
+}


### PR DESCRIPTION
### Issue
Now unable to create integration test, with "live" webservice call.

### Changes
* changed registration of TestWsUriBuilder bean to the spring context, now it can be controlled via property 
* by default it is enabled, even if property is missing, to be backward-compatible as much as possible

### Documentation
* is there already any info on confluence about TestWsUriBuilder? if not and PR is approved, I will add some mention and that it can be disabled/enabled here: https://openhubframework.atlassian.net/wiki/spaces/OHF/pages/8814613/How+to+write+unit+test