### PR TITLE
[OHFJIRA-100] : CloseableHttpComponentsMessageSender moved to api module

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -51,6 +51,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.ws</groupId>
+            <artifactId>spring-ws-core</artifactId>
+        </dependency>
         <!-- enabled configuration properties in OHF classes -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -69,6 +73,10 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-http4</artifactId>
         </dependency>
 
         <!-- test libs -->

--- a/common/src/main/java/org/openhubframework/openhub/common/ws/transport/http/CloseableHttpComponentsMessageSender.java
+++ b/common/src/main/java/org/openhubframework/openhub/common/ws/transport/http/CloseableHttpComponentsMessageSender.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.openhubframework.openhub.core.common.ws.transport.http;
+package org.openhubframework.openhub.common.ws.transport.http;
 
 import java.io.IOException;
 import java.net.URI;

--- a/common/src/test/java/org/openhubframework/openhub/common/properties/OpenHubExternalPropertiesAutoConfigurationTest.java
+++ b/common/src/test/java/org/openhubframework/openhub/common/properties/OpenHubExternalPropertiesAutoConfigurationTest.java
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
 import org.springframework.core.io.PathResource;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.ReflectionUtils;
 
 
@@ -85,6 +86,9 @@ public class OpenHubExternalPropertiesAutoConfigurationTest {
                     .loadClass(TestApplication.class.getName());
             Object instance = springApplicationClass.getConstructor(Object[].class)
                     .newInstance(new Object[] { new Object[] { testApplicationClass } });
+            // without web
+            ReflectionTestUtils.setField(instance, "webEnvironment", false);
+
             @SuppressWarnings("resource")
             ConfigurableApplicationContext ctx = (ConfigurableApplicationContext) ReflectionUtils
                     .findMethod(springApplicationClass, "run", String[].class)


### PR DESCRIPTION
### CloseableHttpComponentsMessageSender 

#### Issue
* in wiki, it is described that openhub-framework provides Http Message Sender : https://openhubframework.atlassian.net/wiki/spaces/OHF/pages/33674/HTTP+Message+Sender
However now it is in core module

#### Changes
* moved class to the core-api module

#### Discussion
* it is breaking change, however it is not in api module. Therefore will it be ok, to just move it & describe in release notes? or should we go with Deprecation and duplicating class till next major release?