### PR TITLE
[OHFJIRA-96] : Camel core version updated to 2.21.3

### DIFF
--- a/core/src/main/java/org/openhubframework/openhub/core/common/camel/ApplicationContextsRegistry.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/camel/ApplicationContextsRegistry.java
@@ -33,6 +33,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ApplicationContextEvent;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.ContextStartedEvent;
+import org.springframework.core.Ordered;
 import org.springframework.util.Assert;
 
 /**
@@ -44,9 +45,16 @@ import org.springframework.util.Assert;
  * @see DefaultCamelContext#setRegistry(Registry)
  * @since 2.0
  */
-public class ApplicationContextsRegistry implements Registry, ApplicationListener<ApplicationContextEvent> {
+public class ApplicationContextsRegistry implements Registry, ApplicationListener<ApplicationContextEvent>, Ordered {
 
     private static final Logger LOG = LoggerFactory.getLogger(ApplicationContextsRegistry.class);
+
+    /**
+     * Order of listener for application events.
+     * It is important to receive event ContextRefreshedEvent before
+     * {@link org.apache.camel.spring.boot.RoutesCollector} does.
+     */
+    public static final int ORDER = LOWEST_PRECEDENCE - 20;
 
     /**
      * List of registers for all application contexts.
@@ -144,5 +152,10 @@ public class ApplicationContextsRegistry implements Registry, ApplicationListene
             LOG.info("Create new registry for context '{}.'", applicationContext.getDisplayName());
             applicationContextsRegistry.put(applicationContext, new ApplicationContextRegistry(applicationContext));
         }
+    }
+
+    @Override
+    public int getOrder() {
+        return ORDER;
     }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/quartz/scheduler/DefaultScheduler.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/quartz/scheduler/DefaultScheduler.java
@@ -441,6 +441,11 @@ public class DefaultScheduler implements Scheduler {
     }
 
     @Override
+    public void resetTriggerFromErrorState(final TriggerKey triggerKey) throws SchedulerException {
+        getScheduler().resetTriggerFromErrorState(triggerKey);
+    }
+
+    @Override
     public void addCalendar(String calName, Calendar calendar, boolean replace, boolean updateTriggers) throws SchedulerException {
         getScheduler().addCalendar(calName, calendar, replace, updateTriggers);
     }

--- a/core/src/test/java/org/openhubframework/openhub/core/reqres/RequestResponseTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/reqres/RequestResponseTest.java
@@ -176,54 +176,6 @@ public class RequestResponseTest extends AbstractCoreDbTest {
     }
 
     /**
-     * Test saving response only, there is no request.
-     */
-    @Test
-    public void testSavingResponseOnly() throws Exception {
-        setPrivateField(reqSendingEventNotifier, "enable", new FixedConfigurationItem<>(Boolean.FALSE));
-
-        // prepare target route
-        prepareTargetRoute(TARGET_URI, null);
-
-        // action
-        mock.expectedMessageCount(1);
-        producer.sendBody(REQUEST);
-
-        // verify
-        TypedQuery<Request> queryReq = em.createQuery("FROM " + Request.class.getName(), Request.class);
-        List<Request> requests = queryReq.getResultList();
-        assertThat(requests.size(), is(0));
-
-        TypedQuery<Response> queryRes = em.createQuery("FROM " + Response.class.getName(), Response.class);
-        List<Response> responses = queryRes.getResultList();
-        assertThat(responses.size(), is(1));
-    }
-
-    /**
-     * Test saving response with message only, there is no request.
-     */
-    @Test
-    @Transactional
-    public void testSavingResponseWithMsgOnly() throws Exception {
-        setPrivateField(reqSendingEventNotifier, "enable", new FixedConfigurationItem<>(Boolean.FALSE));
-
-        // prepare target route
-        prepareTargetRoute(TARGET_URI, null);
-
-        // action
-        mock.expectedMessageCount(1);
-
-        Message msg = insertMessage();
-
-        producer.sendBodyAndHeader(REQUEST, AsynchConstants.MSG_HEADER, msg);
-
-        // verify
-        TypedQuery<Response> queryRes = em.createQuery("FROM " + Response.class.getName(), Response.class);
-        List<Response> responses = queryRes.getResultList();
-        assertThat(responses.size(), is(1));
-    }
-
-    /**
      * Test saving asynchronous request/response with correct calling target endpoint.
      */
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,24 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- Apache Camel libraries -->
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-quartz2</artifactId>
+                <version>${camel-version}</version>
+                <exclusions>
+                    <!-- using HikariCP artifact -->
+                    <exclusion>
+                        <groupId>com.zaxxer</groupId>
+                        <artifactId>HikariCP-java6</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.mchange</groupId>
+                        <artifactId>c3p0</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
             <!-- Enabled configuration properties in OHF classes -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
         <spring-boot.version>1.5.17.RELEASE</spring-boot.version>
         <start-class>org.openhubframework.openhub.OpenHubApplication</start-class>
 
-        <camel-version>2.18.2</camel-version>
+        <camel-version>2.21.3</camel-version>
 
         <!-- persistence -->
         <postgresql-version>9.4-1201-jdbc41</postgresql-version>

--- a/test/src/main/java/org/openhubframework/openhub/test/route/ActiveRoutesCollector.java
+++ b/test/src/main/java/org/openhubframework/openhub/test/route/ActiveRoutesCollector.java
@@ -129,9 +129,7 @@ public class ActiveRoutesCollector extends RoutesCollector {
         for (RoutesBuilder routesBuilder : applicationContext.getBeansOfType(RoutesBuilder.class).values()) {
             // filter out abstract classes
             boolean abs = Modifier.isAbstract(routesBuilder.getClass().getModifiers());
-            // filter out FatJarRouter which can be in the spring app context
-            boolean farJarRouter = FatJarRouter.class.equals(routesBuilder.getClass());
-            if (!abs && !farJarRouter) {
+            if (!abs) {
                 try {
                     if (initAllRoutes) {
                         LOG.debug("Injecting following route into the CamelContext: {}", routesBuilder);


### PR DESCRIPTION
## Upgrade to Camel core 2.21.3

* it is the latest version (2.21.x) supporting Spring Boot 1.5.x

### Changes needed
* Order of camel´s RoutesCollector has changed: added Order for **ApplicationContextsRegistry**, as it initialises itself on ContextRefreshedEvent. It needs to receive the event before **RoutesCollector**, otherwise camel context **won´t start**, as registry is empty
* FatJarRouter : removed entirely, see: https://stackoverflow.com/questions/44723205/using-fatjarrouter-when-upgrading-camel-spring-boot-from-2-18-to-2-19 , therefore removed the handling.
* Quartz: quartz Scheduler interface has new method (quartz 2.2.3 -> quartz 2.3.0), added implementation. other than that quartz update should be about bugfixes, https://github.com/quartz-scheduler/quartz/releases/tag/quartz-2.3.0, database schema is kept intact

### Issue to resolve
Two unit tests are now failing. It is test of RequestResponseTest:
testSavingResponseOnly
testSavingResponseWithMsgOnly

Meaning - saving response without request (only ResponseReceiveEventNotifier is active, RequestSendingEventNotifier is NOT).

Reason is this optimalization in Camel: https://issues.apache.org/jira/browse/CAMEL-11346 which made some changes in camel 2.20.x+, see this commit https://github.com/apache/camel/commit/fdfd57d47684ef575f2dc15b9309978aa071890c
and changes in SendProducer class. It effectivelly means, that ExchangeSentEvent is emitted only if EventHelper.notifyExchangeSending(...) returns true = meaning there is listener for ExchangeSendingEvent. It means, that ResponseReceiveEventNotifier does not work properly without RequestSendingEventNotifier enabled.

Do we still want to support this scenario - response only saving? If yes, I am afraid it will lead to some "hackish" solution like that Response is pretending to be consumer of ExchangeSendingEvent as well, or to have regular support for "two event" listeners.