### PR TITLE
[OHFJIRA-87] : changed registration of configuration properties

### DIFF
--- a/core/src/main/java/org/openhubframework/openhub/core/alerts/AlertsPropertiesConfiguration.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/alerts/AlertsPropertiesConfiguration.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
 import org.openhubframework.openhub.common.Tools;
@@ -39,7 +39,7 @@ import org.openhubframework.openhub.spi.alerts.AlertInfo;
  * @author Petr Juza
  * @since 0.4
  */
-@Service
+@Component
 public class AlertsPropertiesConfiguration extends AbstractAlertsConfiguration {
 
     public static final String ALERT_PROP_PREFIX = "alerts.";

--- a/core/src/main/java/org/openhubframework/openhub/core/throttling/ThrottlingPropertiesConfiguration.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/throttling/ThrottlingPropertiesConfiguration.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
 import org.openhubframework.openhub.common.Tools;
@@ -40,7 +40,7 @@ import org.openhubframework.openhub.spi.throttling.ThrottleScope;
  *
  * @author Petr Juza
  */
-@Service
+@Component
 public class ThrottlingPropertiesConfiguration extends AbstractThrottlingConfiguration {
 
     static final String PROPERTY_PREFIX = "throttling.";

--- a/web/src/test/java/org/openhubframework/openhub/OpenHubApplicationTest.java
+++ b/web/src/test/java/org/openhubframework/openhub/OpenHubApplicationTest.java
@@ -1,0 +1,27 @@
+package org.openhubframework.openhub;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openhubframework.openhub.common.Profiles;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Simple test to check spring context is configured properly.
+ *
+ * @author Karel Kovarik
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        classes = OpenHubApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({Profiles.H2})
+public class OpenHubApplicationTest {
+
+    @Test
+    public void context_loads() {
+        // nothing in here, fails if spring context does not start at all.
+    }
+}


### PR DESCRIPTION
Changed registration of configuration properties used in jmx - AlertsPropertiesConfiguration & ThrottlingPropertiesConfiguration.

As they are used in AlertsJmxConfiguration and JmxThrottlingConfiguration, directly as classes, it causes issues with proxying of Services.