### PR TITLE
[NOJIRA] : travis - build image switch to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     token:
       secure: $SONAR_TOKEN
 jdk:
-  - oraclejdk8
+  - openjdk8
 env:
   global:
   - secure: Ba4t6j5JmDamuCPj8ed4900/X8Nqw8Iyh5bQmp+JBRvf5jcWmurSuddhuXp09puUgRFiOgMGMqE/LyvnnjYNMQFuagZNHMNO9gBdbLPsUs1SbiR399XIaIEnkur4VEjHZp6Jr9WseaOh8mZlNKNZmYKyb5nQLCbTgzdgWY/bFsDVVTvQq/SkBBUoPN/MHWsCOtDoixjkeAfkdHm1gOBrA5+UP4Yg/tJgJWpPecalbRp42o29S93Dh6h+0teeCib+t0Jy3qGIFCRA6NbRyXF44xj31WnD75Vj6iBr6JHz7p+Viu2CRL2LcCbdlMFV2et4Evk/KosmEih0yLgeHrFYvLXobPVike9SgsvDOsXiKoLK4huK6QJflyhXQlglA3Qak3ycLD1/SY2PmJ+ZxgFPcT4oubgpL/0L5G5lCtHb86s8P/Q29Tq0l/4WO8JtNVoxzdsqSu9glMeupumzP5rPZ479ZQ0Ice3rCcPuihqz4GAwhGC48lbhGgY2F+AFngGkvVELa4R0njgrZxFLxN792ykHFjBcwc1AlHWgCfe8/rzan3wK6TKpUeQ+PYMGWsaLYB9HaN4XPKn19xupHUw5xQ0sZKWZuknbLsabGmItiqlqfGY/nQbCoobfRhrYm24Zm6HJV90Nz04K3okiRMUPUs/EEb3gb+M6cBUhi6rZzUc=


### PR DESCRIPTION
Backport of commit from develop. 
Does fix failing build, as release/2.1 branch still uses oracle jdk instead of openjdk on travis:

https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038