### PR TITLE
[OHFJIRA-107] : fixed final message processing of messages without re…

### DIFF
--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/finalmessage/DeleteFinalMessageProcessor.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/finalmessage/DeleteFinalMessageProcessor.java
@@ -96,7 +96,9 @@ public class DeleteFinalMessageProcessor extends AbstractFinalMessageProcessor {
             LOG.debug("Will delete request [{}] and response [{}].",
                     request.getId(),
                     request.getResponse() != null ? request.getResponse().getId() : null);
-            requestResponseDao.deleteResponse(request.getResponse());
+            if (request.getResponse() != null) {
+                requestResponseDao.deleteResponse(request.getResponse());
+            }
             requestResponseDao.deleteRequest(request);
         }
     }


### PR DESCRIPTION
### Issue

- when final message processing job is turned on
- saving requests and responses is turned on
- output message is without response (messaging is used)
- message is not deleted with error: `the response must not be null.; nested exception is java.lang.IllegalArgumentException: the response must not be null.`

### Changes
- added check for empty response
