### PR TITLE
[OHFJIRA-109] : changed selection of partly failed and postponed mess…

### DIFF
--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
@@ -30,7 +30,6 @@ import org.apache.camel.ExchangeProperty;
 import org.apache.camel.Header;
 import org.apache.camel.Properties;
 
-import org.openhubframework.openhub.api.entity.ExternalSystemExtEnum;
 import org.openhubframework.openhub.api.entity.Message;
 import org.openhubframework.openhub.api.entity.MessageFilter;
 import org.openhubframework.openhub.api.entity.MsgStateEnum;
@@ -259,4 +258,14 @@ public interface MessageService {
      */
     @Nullable
     Message findPartlyFailedMessage(Duration interval);
+
+    /**
+     * Finds one message in state {@link MsgStateEnum#POSTPONED} or {@link MsgStateEnum#PARTLY_FAILED}
+     *
+     * @param postponedInterval Interval (in seconds) after that can be postponed message processed again
+     * @param partiallyFailedInterval Interval (in seconds) after that can be partly failed message processed again
+     * @return message or null if there is no any message
+     */
+    @Nullable
+    Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partiallyFailedInterval);
 }

--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
@@ -263,9 +263,9 @@ public interface MessageService {
      * Finds one message in state {@link MsgStateEnum#POSTPONED} or {@link MsgStateEnum#PARTLY_FAILED}
      *
      * @param postponedInterval Interval (in seconds) after that can be postponed message processed again
-     * @param partiallyFailedInterval Interval (in seconds) after that can be partly failed message processed again
+     * @param partlyFailedInterval Interval (in seconds) after that can be partly failed message processed again
      * @return message or null if there is no any message
      */
     @Nullable
-    Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partiallyFailedInterval);
+    Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partlyFailedInterval);
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
@@ -511,4 +511,13 @@ public class MessageServiceImpl implements MessageService {
 
         return messageDao.findPartlyFailedMessage(interval);
     }
+
+    @Nullable
+    @Override
+    public Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partiallyFailedInterval) {
+        Assert.notNull(postponedInterval, "postponed interval must not be null");
+        Assert.notNull(partiallyFailedInterval, "partly failed interval must not be null");
+
+        return messageDao.findPostponedOrPartlyFailedMessage(postponedInterval, partiallyFailedInterval);
+    }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
@@ -514,10 +514,10 @@ public class MessageServiceImpl implements MessageService {
 
     @Nullable
     @Override
-    public Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partiallyFailedInterval) {
+    public Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partlyFailedInterval) {
         Assert.notNull(postponedInterval, "postponed interval must not be null");
-        Assert.notNull(partiallyFailedInterval, "partly failed interval must not be null");
+        Assert.notNull(partlyFailedInterval, "partly failed interval must not be null");
 
-        return messageDao.findPostponedOrPartlyFailedMessage(postponedInterval, partiallyFailedInterval);
+        return messageDao.findPostponedOrPartlyFailedMessage(postponedInterval, partlyFailedInterval);
     }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/queue/MessagesPoolImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/queue/MessagesPoolImpl.java
@@ -64,12 +64,7 @@ public class MessagesPoolImpl implements MessagesPool {
         // is there next message for processing?
 
         // firstly try postponed messages
-        Message msg = findPostponedMessage();
-
-        // then partly failed messages
-        if (msg == null) {
-            msg = findPartlyFailedMessage();
-        }
+        Message msg = findPostponedOrPartlyFailedMessage();
 
         if (msg == null) {
             LOG.debug("No POSTPONED and PARTLY_FAILED message found for re-processing.");
@@ -86,12 +81,8 @@ public class MessagesPoolImpl implements MessagesPool {
     }
 
     @Nullable
-    private Message findPostponedMessage() {
-        return messageService.findPostponedMessage(postponedInterval.getValue().toDuration());
-    }
-
-    @Nullable
-    private Message findPartlyFailedMessage() {
-        return messageService.findPartlyFailedMessage(partlyFailedInterval.getValue().toDuration());
+    private Message findPostponedOrPartlyFailedMessage() {
+        return messageService.findPostponedOrPartlyFailedMessage(postponedInterval.getValue().toDuration(),
+                partlyFailedInterval.getValue().toDuration());
     }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
@@ -126,6 +126,16 @@ public interface MessageDao {
     Message findPostponedMessage(Duration interval);
 
     /**
+     * Finds ONE message in state {@link MsgStateEnum#POSTPONED} or {@link MsgStateEnum#PARTLY_FAILED}
+     *
+     * @param postponedInterval Interval (in seconds) after that can be postponed message processed again
+     * @param partiallyFailedInterval Interval (in seconds) after that can be partly failed message processed again
+     * @return message or null if there is no any message
+     */
+    @Nullable
+    Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partiallyFailedInterval);
+
+    /**
      * Updates {@link Message} into state {@link MsgStateEnum#PROCESSING} (set start timestamp of processing)
      * - gets lock for message.
      *

--- a/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
@@ -129,11 +129,11 @@ public interface MessageDao {
      * Finds ONE message in state {@link MsgStateEnum#POSTPONED} or {@link MsgStateEnum#PARTLY_FAILED}
      *
      * @param postponedInterval Interval (in seconds) after that can be postponed message processed again
-     * @param partiallyFailedInterval Interval (in seconds) after that can be partly failed message processed again
+     * @param partlyFailedInterval Interval (in seconds) after that can be partly failed message processed again
      * @return message or null if there is no any message
      */
     @Nullable
-    Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partiallyFailedInterval);
+    Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partlyFailedInterval);
 
     /**
      * Updates {@link Message} into state {@link MsgStateEnum#PROCESSING} (set start timestamp of processing)

--- a/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDaoJpaImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDaoJpaImpl.java
@@ -207,6 +207,32 @@ public class MessageDaoJpaImpl implements MessageDao {
         }
     }
 
+    @Nullable
+    @Override
+    public Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partiallyFailedInterval) {
+        // find message that was lastly processed before specified intervals
+
+        String jSql = "SELECT m "
+                + "FROM " + Message.class.getName() + " m "
+                + "WHERE (m.state = '" + MsgStateEnum.POSTPONED + "'"
+                + "        AND m.lastUpdateTimestamp < :lastTimePostponed)"
+                + "   OR (m.state = '" + MsgStateEnum.PARTLY_FAILED + "'"
+                + "        AND m.lastUpdateTimestamp < :lastTimePartlyFailed)"
+                + " ORDER BY m.msgTimestamp";
+
+        TypedQuery<Message> q = em.createQuery(jSql, Message.class);
+        q.setParameter("lastTimePostponed", Instant.now().minus(postponedInterval));
+        q.setParameter("lastTimePartlyFailed", Instant.now().minus(partiallyFailedInterval));
+        q.setMaxResults(1);
+        List<Message> messages = q.getResultList();
+
+        if (messages.isEmpty()) {
+            return null;
+        } else {
+            return messages.get(0);
+        }
+    }
+
     @Override
     @Transactional(propagation = Propagation.MANDATORY)
     public boolean updateMessageProcessingUnderLock(Message msg, Node processingNode) {

--- a/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDaoJpaImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDaoJpaImpl.java
@@ -209,7 +209,7 @@ public class MessageDaoJpaImpl implements MessageDao {
 
     @Nullable
     @Override
-    public Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partiallyFailedInterval) {
+    public Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partlyFailedInterval) {
         // find message that was lastly processed before specified intervals
 
         String jSql = "SELECT m "
@@ -222,7 +222,7 @@ public class MessageDaoJpaImpl implements MessageDao {
 
         TypedQuery<Message> q = em.createQuery(jSql, Message.class);
         q.setParameter("lastTimePostponed", Instant.now().minus(postponedInterval));
-        q.setParameter("lastTimePartlyFailed", Instant.now().minus(partiallyFailedInterval));
+        q.setParameter("lastTimePartlyFailed", Instant.now().minus(partlyFailedInterval));
         q.setMaxResults(1);
         List<Message> messages = q.getResultList();
 


### PR DESCRIPTION
### Current
MessagesPool finds messages in the PARTLY_FAILED and POSTPONED state for further processing. Currently all postponed messages are processed first and then are processed all partly failed messages. 

This behaviour has negative performance impact in combination with messages in guaranteed order. If there are many POSTPONED messages and the oldest message is in PARTLY_FAILED state then MessagesPool has to go through all POSTPONED messages but they can't be processed. 

### Improvement
This improvement combines selection of these two message groups into common SQL query. 