### PR TITLE
[OHFJIRA-102] : added new configuration parameter for enabling admin emails

### DIFF
--- a/core-api/src/main/java/org/openhubframework/openhub/api/configuration/CoreProps.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/configuration/CoreProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,6 +119,11 @@ public class CoreProps {
      * Suffix to be used in conjuction with {@link CoreProps.ASYNCH_FINAL_MESSAGES_PREFIX}.
      */
     public static final String ASYNCH_FINAL_MESSAGES_SAVE_TIME_IN_SEC_SUFFIX = ".saveTimeInSec";
+
+    /**
+     * Sending emails to administrators enabled or disabled.
+     */
+    public static final String MAIL_ADMIN_ENABLED = PREFIX + "mail.admin.enabled";
 
     /**
      * Administrator email(s); if more emails, then separated them with semicolon, if empty then email won't be sent.

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/notification/EmailServiceCamelSmtpImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/notification/EmailServiceCamelSmtpImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.openhubframework.openhub.core.common.asynch.notification;
 
 import static org.openhubframework.openhub.api.configuration.CoreProps.MAIL_ADMIN;
+import static org.openhubframework.openhub.api.configuration.CoreProps.MAIL_ADMIN_ENABLED;
 import static org.openhubframework.openhub.api.configuration.CoreProps.MAIL_FROM;
 import static org.openhubframework.openhub.api.configuration.CoreProps.MAIL_SMTP_SERVER;
 
@@ -47,6 +48,12 @@ public class EmailServiceCamelSmtpImpl implements EmailService {
     private ProducerTemplate producerTemplate;
 
     /**
+     * Enabling sending emails to administrators.
+     */
+    @ConfigurableValue(key = MAIL_ADMIN_ENABLED)
+    private ConfigurationItem<Boolean> enabled;
+
+    /**
      * Administrator email address.
      */
     @ConfigurableValue(key = MAIL_ADMIN)
@@ -66,7 +73,9 @@ public class EmailServiceCamelSmtpImpl implements EmailService {
 
     @Override
     public void sendEmailToAdmins(String subject, String body) {
-        sendFormattedEmail(recipients.getValue(), subject, body);
+        if (enabled.getValue()) {
+            sendFormattedEmail(recipients.getValue(), subject, body);
+        }
     }
 
     @Override

--- a/core/src/main/resources/db/migration/h2/V1_0_4__email_property.sql
+++ b/core/src/main/resources/db/migration/h2/V1_0_4__email_property.sql
@@ -1,0 +1,3 @@
+-- true for enabling sending emails to administrators
+INSERT INTO configuration_item (code, category_code, current_value, default_value, data_type, mandatory, validation)
+    VALUES('ohf.mail.admin.enabled', 'core.mail', 'false', 'false', 'BOOLEAN', true, null);

--- a/core/src/main/resources/db/migration/postgresql/V1_0_4__email_property.sql
+++ b/core/src/main/resources/db/migration/postgresql/V1_0_4__email_property.sql
@@ -1,0 +1,3 @@
+-- true for enabling sending emails to administrators
+INSERT INTO configuration_item (code, category_code, current_value, default_value, data_type, mandatory, validation)
+    VALUES('ohf.mail.admin.enabled', 'core.mail', 'false', 'false', 'BOOLEAN', true, null);

--- a/core/src/test/java/org/openhubframework/openhub/core/common/asynch/notification/EmailServiceCamelSmtpImplTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/common/asynch/notification/EmailServiceCamelSmtpImplTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.common.asynch.notification;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.ProducerTemplate;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+
+import org.openhubframework.openhub.api.common.EmailService;
+import org.openhubframework.openhub.core.AbstractCoreDbTest;
+import org.openhubframework.openhub.core.configuration.FixedConfigurationItem;
+
+
+/**
+ * Test suite for {@link EmailServiceCamelSmtpImpl}.
+ *
+ * @author Michal Sabol
+ */
+@ContextConfiguration(classes = {
+        EmailServiceCamelSmtpImplTest.TestContext.class
+})
+public class EmailServiceCamelSmtpImplTest extends AbstractCoreDbTest {
+
+    private static final String TEST_SUBJECT = "Test notification email";
+
+    private static final String TEST_BODY = "Test notification email with body";
+
+    @Autowired
+    @Qualifier("testEmailService")
+    private EmailService emailService;
+
+    @MockBean
+    private ProducerTemplate producerTemplateMock;
+
+    @Before
+    public void prepareData() {
+        setPrivateField(emailService, "recipients", new FixedConfigurationItem<>("admin@oh.or"));
+        setPrivateField(emailService, "smtp", new FixedConfigurationItem<>("smtp.server"));
+    }
+
+    @Test
+    public void testSendEmailToAdmins_enabled() {
+        setPrivateField(emailService, "enabled", new FixedConfigurationItem<>(Boolean.TRUE));
+
+        emailService.sendEmailToAdmins(TEST_SUBJECT, TEST_BODY);
+
+        verify(producerTemplateMock, times(1)).sendBodyAndHeaders(eq("smtp://smtp.server"), eq(TEST_BODY), any());
+    }
+
+    @Test
+    public void testSendEmailToAdmins_disabled() {
+        setPrivateField(emailService, "enabled", new FixedConfigurationItem<>(Boolean.FALSE));
+
+        emailService.sendEmailToAdmins(TEST_SUBJECT, TEST_BODY);
+
+        verify(producerTemplateMock, never()).sendBodyAndHeaders(eq("smtp://smtp.server"), eq(TEST_BODY), any());
+    }
+
+    @Test
+    public void testSendFormattedEmail_ok() {
+        final String recipients = "admin@oh.or";
+        final String from = "openhub@openwise.cz";
+        setPrivateField(emailService, "from", new FixedConfigurationItem<>(from));
+
+        emailService.sendFormattedEmail(recipients, TEST_SUBJECT, TEST_BODY);
+
+        final Map<String, Object> expected = new HashMap<>();
+        expected.put("To", recipients);
+        expected.put("From", from);
+        expected.put("Subject", TEST_SUBJECT);
+
+        verify(producerTemplateMock, times(1)).sendBodyAndHeaders(eq("smtp://smtp.server"), eq(TEST_BODY), eq(expected));
+    }
+
+    @Test
+    public void testSendFormattedEmail_noRecipients() {
+        emailService.sendFormattedEmail(null, TEST_SUBJECT, TEST_BODY);
+
+        verify(producerTemplateMock, never()).sendBodyAndHeaders(eq("smtp://smtp.server"), eq(TEST_BODY), any());
+    }
+
+    public static class TestContext {
+
+        @Bean("testEmailService")
+        public EmailService getTestEmailService() {
+            return new EmailServiceCamelSmtpImpl();
+        }
+    }
+}


### PR DESCRIPTION
### ISSUE
When message fails then email is sent to recipients defined by `ohf.mail.admin` parameter. If parameter is empty then email won't be sent. So it's not clear how to enable or disable this feature.

### CHANGES
Add new parameter `ohf.mail.admin.enabled` for switching on/off for sending admin emails.
Added parameter to default DB configuration with value `false`.

### DOCUMENTATION
Documentation needs to be extended on page  https://openhubframework.atlassian.net/wiki/spaces/OHF/pages/33599/OpenHub+configuration