### PR TITLE
[OHFJIRA-110] : guaranteed order messages query optimization

### DIFF
--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,9 +208,24 @@ public interface MessageService {
      * @param funnelValue the funnel value
      * @param excludeFailedState {@link MsgStateEnum#FAILED FAILED} state is used by default;
      *                           use {@code true} if you want to exclude FAILED state
-     * @return list of messages ordered by {@link Message#getMsgTimestamp() message timestamp}
+     * @return list of all messages ordered by {@link Message#getMsgTimestamp() message timestamp}
+     * @deprecated use {@link #getMessagesForGuaranteedOrderForRoute(String, boolean, long)} instead, which returns
+     *             specified number of records
      */
+    @Deprecated
     List<Message> getMessagesForGuaranteedOrderForRoute(String funnelValue, boolean excludeFailedState);
+
+    /**
+     * Gets list of messages with specified funnel value for guaranteed processing order of whole routes.
+     *
+     * @param funnelValue the funnel value
+     * @param excludeFailedState {@link MsgStateEnum#FAILED FAILED} state is used by default;
+     *                           use {@code true} if you want to exclude FAILED state
+     * @param limit the limit of message count
+     * @return list of messages ordered by {@link Message#getMsgTimestamp() message timestamp} and
+     *         {@link Message#getMsgId() message id}
+     */
+    List<Message> getMessagesForGuaranteedOrderForRoute(String funnelValue, boolean excludeFailedState, long limit);
 
     /**
      * Gets list of messages with specified funnel value for guaranteed processing order of messages

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchInMessageRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchInMessageRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,6 +84,8 @@ public class AsynchInMessageRoute extends AbstractBasicRoute {
     static final String URI_GUARANTEED_ORDER_ROUTE = "direct:guaranteedOrderRoute";
 
     static final String ROUTE_ID_GUARANTEED_ORDER = "guaranteedOrder" + AbstractBasicRoute.ROUTE_SUFFIX;
+
+    private static final long GUARANTEED_ORDER_MESSAGES_LIMIT = 2L;
 
     @Autowired
     private ThrottlingProcessor throttlingProcessor;
@@ -269,7 +271,7 @@ public class AsynchInMessageRoute extends AbstractBasicRoute {
         } else {
             // guaranteed order => is the message in the right order?
             List<Message> messages = getBean(MessageService.class)
-                    .getMessagesForGuaranteedOrderForRoute(msg.getFunnelValue(), msg.isExcludeFailedState());
+                    .getMessagesForGuaranteedOrderForRoute(msg.getFunnelValue(), msg.isExcludeFailedState(), GUARANTEED_ORDER_MESSAGES_LIMIT);
 
             if (messages.size() == 1) {
                 LOG.debug("There is only one processing message with funnel value: " + msg.getFunnelValue()

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -450,6 +450,11 @@ public class MessageServiceImpl implements MessageService {
     @Override
     public List<Message> getMessagesForGuaranteedOrderForRoute(String funnelValue, boolean excludeFailedState) {
         return messageDao.getMessagesForGuaranteedOrderForRoute(funnelValue, excludeFailedState);
+    }
+
+    @Override
+    public List<Message> getMessagesForGuaranteedOrderForRoute(String funnelValue, boolean excludeFailedState, long limit) {
+        return messageDao.getMessagesForGuaranteedOrderForRoute(funnelValue, excludeFailedState, limit);
     }
 
     @Override

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/queue/MessagePollExecutor.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/queue/MessagePollExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,8 @@ public class MessagePollExecutor implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(MessagePollExecutor.class);
 
     private static final int LOCK_FAILURE_LIMIT = 5;
+
+    private static final long GUARANTEED_ORDER_MESSAGES_LIMIT = 2L;
 
     @Autowired
     private MessagesPool messagesPool;
@@ -175,7 +177,7 @@ public class MessagePollExecutor implements Runnable {
         } else {
             // guaranteed order => is the message in the right order?
             List<Message> messages = messageService.getMessagesForGuaranteedOrderForRoute(msg.getFunnelValue(),
-                    msg.isExcludeFailedState());
+                    msg.isExcludeFailedState(), GUARANTEED_ORDER_MESSAGES_LIMIT);
 
             if (messages.size() == 1) {
                 LOG.debug("There is only one processing message with funnel value: " + msg.getFunnelValue()

--- a/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,9 +190,24 @@ public interface MessageDao {
      * @param funnelValue the funnel value
      * @param excludeFailedState {@link MsgStateEnum#FAILED FAILED} state is used by default;
      *                           use {@code true} if you want to exclude FAILED state
-     * @return list of messages ordered by {@link Message#getMsgTimestamp() message timestamp}
+     * @return list of all messages ordered by {@link Message#getMsgTimestamp() message timestamp}
+     * @deprecated use {@link #getMessagesForGuaranteedOrderForRoute(String, boolean, long)} instead, which returns
+     *             specified number of records
      */
+    @Deprecated
     List<Message> getMessagesForGuaranteedOrderForRoute(String funnelValue, boolean excludeFailedState);
+
+    /**
+     * Gets list of messages with specified funnel value for guaranteed processing order of whole routes.
+     *
+     * @param funnelValue the funnel value
+     * @param excludeFailedState {@link MsgStateEnum#FAILED FAILED} state is used by default;
+     *                           use {@code true} if you want to exclude FAILED state
+     * @param limit the limit of message count
+     * @return list of messages ordered by {@link Message#getMsgTimestamp() message timestamp} and
+     *         {@link Message#getMsgId() message id}
+     */
+    List<Message> getMessagesForGuaranteedOrderForRoute(String funnelValue, boolean excludeFailedState, long limit);
 
     /**
      * Gets list of messages with specified funnel value for guaranteed processing order of messages


### PR DESCRIPTION
### ISSUE
There is dao `getMessagesForGuaranteedOrderForRoute` which returns list of all messages which fits the query conditions (there isn't limit). This has negative performance impact (memory, time) for messages in guaranteed order. 

### CHANGES
- added new method `getMessagesForGuaranteedOrderForRoute` with `limit` to MessageService and MessageDAO
- deprecated existing `getMessagesForGuaranteedOrderForRoute` methods without limit
- switched all deprecated methods with a new ones
