### PR TITLE
[OHFJIRA-113] : fixed DB throttling disable configuration property

### DIFF
--- a/admin-console/mock-server/config/parameters.mock.js
+++ b/admin-console/mock-server/config/parameters.mock.js
@@ -238,8 +238,8 @@ module.exports = [
           "description": "Pattern for all input URIs into ESB",
           "validationRegEx": null
         }, {
-          "id": "ohf.throttling.disable",
-          "code": "ohf.throttling.disable",
+          "id": "ohf.disable.throttling",
+          "code": "ohf.disable.throttling",
           "categoryCode": "core.throttling",
           "currentValue": "false",
           "defaultValue": "false",

--- a/core/src/main/resources/db/migration/h2/V1_0_5__throttling.sql
+++ b/core/src/main/resources/db/migration/h2/V1_0_5__throttling.sql
@@ -1,0 +1,2 @@
+-- true for disabling throttling at all
+UPDATE configuration_item SET code='ohf.disable.throttling' where code='ohf.throttling.disable';

--- a/core/src/main/resources/db/migration/postgresql/V1_0_5__throttling.sql
+++ b/core/src/main/resources/db/migration/postgresql/V1_0_5__throttling.sql
@@ -1,0 +1,2 @@
+-- true for disabling throttling at all
+UPDATE configuration_item SET code='ohf.disable.throttling' where code='ohf.throttling.disable';


### PR DESCRIPTION
### ISSUE
Changing property `ohf.throttling.disable` in DB hasn't got any effect on enabling/disabling throttling.
Implementation expects property name `ohf.disable.throttling`.

### CHANGES
- changed property name in H2 and Postgresql scripts to `ohf.disable.throttling`
- fixed fe mocks