### PR TITLE
[OHFJIRA-111] : process the following message in guaranteed order

### DIFF
--- a/core-api/src/main/java/org/openhubframework/openhub/api/event/CompletedGuaranteedOrderMsgAsynchEvent.java
+++ b/core-api/src/main/java/org/openhubframework/openhub/api/event/CompletedGuaranteedOrderMsgAsynchEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.api.event;
+
+import org.apache.camel.Exchange;
+import org.openhubframework.openhub.api.entity.Message;
+import org.openhubframework.openhub.api.entity.MsgStateEnum;
+import org.springframework.util.Assert;
+
+
+/**
+ * Event for successfully completed message in guaranteed order,
+ * i.e. the message is in {@link MsgStateEnum#OK} state and in guaranteed order at the same time
+ *
+ * @author Michal Sabol
+ */
+public class CompletedGuaranteedOrderMsgAsynchEvent extends AbstractAsynchEvent {
+
+    /**
+     * Creates new event.
+     *
+     * @param exchange the exchange
+     * @param message the message
+     */
+    public CompletedGuaranteedOrderMsgAsynchEvent(Exchange exchange, Message message) {
+        super(exchange, message);
+
+        Assert.isTrue(message.getState() == MsgStateEnum.OK,
+                "the message must be in the state " + MsgStateEnum.OK);
+        Assert.isTrue(message.isGuaranteedOrder(),
+                "the message must be in guaranteed order");
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getName() + ": the message " + getMessage().toHumanString()
+                + " successfully processed guaranteed ordered message (state = " + MsgStateEnum.OK + ").";
+    }
+}

--- a/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
+++ b/core-spi/src/main/java/org/openhubframework/openhub/spi/msg/MessageService.java
@@ -283,4 +283,13 @@ public interface MessageService {
      */
     @Nullable
     Message findPostponedOrPartlyFailedMessage(Duration postponedInterval, Duration partlyFailedInterval);
+
+    /**
+     * Finds one message with specified funnel value for guaranteed processing order of whole routes.
+     *
+     * @param funnelValue the funnel value
+     * @return the oldest message by {@link Message#getMsgTimestamp() message timestamp} or null
+     */
+    @Nullable
+    Message findPostponedMessage(String funnelValue);
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRoute.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/AsynchMessageRoute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -244,6 +244,7 @@ public class AsynchMessageRoute extends AbstractBasicRoute {
                                 AsynchEventHelper.notifyMsgCompleted(exchange);
                             }
                         })
+                        .bean(ROUTE_BEAN, "notifyCompletedGuaranteedOrderMsg")
 
                         .to(AsynchConstants.URI_POST_PROCESS_AFTER_OK)
                     .end()
@@ -505,6 +506,21 @@ public class AsynchMessageRoute extends AbstractBasicRoute {
 
         if (!nodeService.getActualNode().isAbleToHandleExistingMessages()) {
             throw new StoppingException("ESB has been stopped...");
+        }
+    }
+
+    /**
+     * Sends notifications event when message in guaranteed order completes successfully
+     *
+     * @param msg message which is completed
+     * @param exchange exchange of completed message
+     */
+    @Handler
+    public void notifyCompletedGuaranteedOrderMsg(@Header(MSG_HEADER) Message msg, Exchange exchange) {
+        Assert.notNull(msg, "the msg must not be null");
+
+        if (msg.isGuaranteedOrder()) {
+            AsynchEventHelper.notifyGuaranteedOrderMsgCompleted(exchange);
         }
     }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/asynch/msg/MessageServiceImpl.java
@@ -525,4 +525,12 @@ public class MessageServiceImpl implements MessageService {
 
         return messageDao.findPostponedOrPartlyFailedMessage(postponedInterval, partlyFailedInterval);
     }
+
+    @Nullable
+    @Override
+    public Message findPostponedMessage(String funnelValue) {
+        Assert.hasText(funnelValue, "the funnelValue must not be empty");
+
+        return messageDao.findPostponedMessage(funnelValue);
+    }
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDao.java
@@ -231,4 +231,13 @@ public interface MessageDao {
      * @return list of messages.
      */
     List<Message> findMessagesByFilter(MessageFilter messageFilter, long limit);
+
+    /**
+     * Finds one message with specified funnel value for guaranteed processing order of whole routes.
+     *
+     * @param funnelValue the funnel value
+     * @return the oldest message by {@link Message#getMsgTimestamp() message timestamp} or null
+     */
+    @Nullable
+    Message findPostponedMessage(String funnelValue);
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDaoJpaImpl.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/dao/MessageDaoJpaImpl.java
@@ -553,6 +553,29 @@ public class MessageDaoJpaImpl implements MessageDao {
         return q.getResultList();
     }
 
+    @Nullable
+    @Override
+    public Message findPostponedMessage(String funnelValue) {
+        Assert.notNull(funnelValue, "the funnelValue must not be null");
+
+        String jSql = "SELECT m "
+                + "FROM " + Message.class.getName() + " m "
+                + "WHERE m.state = '" + MsgStateEnum.POSTPONED + "'"
+                + "      AND m.funnelValue = '" + funnelValue + "'"
+                + "      AND m.guaranteedOrder is true"
+                + " ORDER BY m.msgTimestamp";
+
+        TypedQuery<Message> q = em.createQuery(jSql, Message.class);
+        q.setMaxResults(1);
+        List<Message> messages = q.getResultList();
+
+        if (messages.isEmpty()) {
+            return null;
+        } else {
+            return messages.get(0);
+        }
+    }
+
     /**
      * Fulltext SQL used with fulltext field of messageFilter in operation findMessagesByFilter.
      * Note: it is protected, as it could be overriden.

--- a/core/src/main/java/org/openhubframework/openhub/core/common/event/AsynchEventFactory.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/event/AsynchEventFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.openhubframework.openhub.core.common.event;
 
+import org.openhubframework.openhub.api.event.CompletedGuaranteedOrderMsgAsynchEvent;
 import org.openhubframework.openhub.api.event.CompletedMsgAsynchEvent;
 import org.openhubframework.openhub.api.event.FailedMsgAsynchEvent;
 import org.openhubframework.openhub.api.event.PartlyFailedMsgAsynchEvent;
@@ -81,4 +82,11 @@ public interface AsynchEventFactory {
      */
     PostponedMsgAsynchEvent createPostponedMsgEvent(Exchange exchange);
 
+    /**
+     * Creates an {@link CompletedGuaranteedOrderMsgAsynchEvent} for successfully completed asynch message in guaranteed order.
+     *
+     * @param exchange the exchange
+     * @return the created event
+     */
+    CompletedGuaranteedOrderMsgAsynchEvent createCompletedGuaranteedOrderMsgEvent(Exchange exchange);
 }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/event/AsynchEventHelper.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/event/AsynchEventHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,6 +125,20 @@ public final class AsynchEventHelper {
             @Override
             public AbstractAsynchEvent createEvent(Exchange exchange) {
                 return factory.createPostponedMsgEvent(exchange);
+            }
+        });
+    }
+
+    public static void notifyGuaranteedOrderMsgCompleted(Exchange exchange){
+        notifyMsg(exchange, new EventNotifierCallback() {
+            @Override
+            public boolean ignore(EventNotifier notifier) {
+                return notifier.isIgnoreExchangeEvents();
+            }
+
+            @Override
+            public AbstractAsynchEvent createEvent(Exchange exchange) {
+                return factory.createCompletedGuaranteedOrderMsgEvent(exchange);
             }
         });
     }

--- a/core/src/main/java/org/openhubframework/openhub/core/common/event/DefaultAsynchEventFactory.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/common/event/DefaultAsynchEventFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,15 @@ public class DefaultAsynchEventFactory implements AsynchEventFactory {
     @Override
     public PostponedMsgAsynchEvent createPostponedMsgEvent(Exchange exchange) {
         PostponedMsgAsynchEvent event = new PostponedMsgAsynchEvent(exchange, getMsgFromExchange(exchange));
+
+        LOG.debug("New event was created: {}", event);
+
+        return event;
+    }
+
+    @Override
+    public CompletedGuaranteedOrderMsgAsynchEvent createCompletedGuaranteedOrderMsgEvent(Exchange exchange) {
+        CompletedGuaranteedOrderMsgAsynchEvent event = new CompletedGuaranteedOrderMsgAsynchEvent(exchange, getMsgFromExchange(exchange));
 
         LOG.debug("New event was created: {}", event);
 

--- a/core/src/main/java/org/openhubframework/openhub/core/guaranteedorder/GuaranteedOrderMsgEventNotifier.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/guaranteedorder/GuaranteedOrderMsgEventNotifier.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.guaranteedorder;
+
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.ProducerTemplate;
+import org.openhubframework.openhub.api.asynch.AsynchConstants;
+import org.openhubframework.openhub.api.entity.Message;
+import org.openhubframework.openhub.api.event.CompletedGuaranteedOrderMsgAsynchEvent;
+import org.openhubframework.openhub.api.event.EventNotifier;
+import org.openhubframework.openhub.api.event.EventNotifierBase;
+import org.openhubframework.openhub.api.exception.LockFailureException;
+import org.openhubframework.openhub.spi.msg.MessageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.EventListener;
+
+
+/**
+ * Listens to successfully completed message event {@link CompletedGuaranteedOrderMsgAsynchEvent}.
+ * <p/>
+ * The following message in order is found using the funnel value and sent for next processing.
+ *
+ * @author Michal Sabol
+ */
+@EventNotifier
+public class GuaranteedOrderMsgEventNotifier extends EventNotifierBase<CompletedGuaranteedOrderMsgAsynchEvent> {
+
+    @Autowired
+    private MessageService messageService;
+
+    private ProducerTemplate producerTemplate;
+
+    private String targetURI = AsynchConstants.URI_ASYNC_MSG;
+
+    @EventListener
+    public void onApplicationEvent(ApplicationReadyEvent applicationReadyEvent) {
+        ApplicationContext applicationContext = applicationReadyEvent.getApplicationContext();
+        this.producerTemplate = applicationContext.getBean(ProducerTemplate.class);
+    }
+
+    @Override
+    protected void doNotify(CompletedGuaranteedOrderMsgAsynchEvent event) {
+        final Message message = event.getExchange().getIn().getHeader(AsynchConstants.MSG_HEADER, Message.class);
+
+        final Message nextMessage = messageService.findPostponedMessage(message.getFunnelValue());
+
+        if (nextMessage != null) {
+            // try to get lock for the message
+            boolean isLock = messageService.setStateInQueueForLock(nextMessage);
+            if (!isLock) {
+                throw new LockFailureException("Failed to lock message for re-processing: " + nextMessage.toHumanString());
+            }
+
+            log.debug("Found following POSTPONED message: {} with funnel value: {} => send for next processing", nextMessage.toHumanString(),
+                    nextMessage.getFunnelValue());
+
+            // sends message for next processing
+            producerTemplate.sendBodyAndHeader(targetURI, ExchangePattern.InOnly, nextMessage,
+                    AsynchConstants.MSG_QUEUE_INSERT_HEADER, System.currentTimeMillis());
+        }
+    }
+}

--- a/core/src/main/java/org/openhubframework/openhub/core/guaranteedorder/package-info.java
+++ b/core/src/main/java/org/openhubframework/openhub/core/guaranteedorder/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Guaranteed order of messages.
+ */
+package org.openhubframework.openhub.core.guaranteedorder;

--- a/core/src/test/java/org/openhubframework/openhub/core/guaranteedorder/GuaranteedOrderMsgEventNotifierTest.java
+++ b/core/src/test/java/org/openhubframework/openhub/core/guaranteedorder/GuaranteedOrderMsgEventNotifierTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openhubframework.openhub.core.guaranteedorder;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.time.Instant;
+
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.ExchangeBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Before;
+import org.junit.Test;
+import org.openhubframework.openhub.api.asynch.AsynchConstants;
+import org.openhubframework.openhub.api.entity.Message;
+import org.openhubframework.openhub.api.entity.MsgStateEnum;
+import org.openhubframework.openhub.core.AbstractCoreDbTest;
+import org.openhubframework.openhub.core.common.event.AsynchEventHelper;
+import org.openhubframework.openhub.test.data.ExternalSystemTestEnum;
+import org.openhubframework.openhub.test.data.ServiceTestEnum;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
+
+
+/**
+ * Test suite for {@link GuaranteedOrderMsgEventNotifier}.
+ *
+ * @author Michal Sabol
+ */
+public class GuaranteedOrderMsgEventNotifierTest extends AbstractCoreDbTest {
+
+    @EndpointInject(uri = "mock:test")
+    private MockEndpoint mock;
+
+    @Autowired
+    private ProducerTemplate producerTemplate;
+
+    @Autowired
+    private GuaranteedOrderMsgEventNotifier eventNotifier;
+
+    @Before
+    public void prepareData() {
+        setPrivateField(eventNotifier, "targetURI", "mock:test");
+
+        TransactionTemplate txTemplate = new TransactionTemplate(transactionManager);
+        txTemplate.execute(new TransactionCallbackWithoutResult() {
+            @Override
+            protected void doInTransactionWithoutResult(TransactionStatus status) {
+                insertNewMessage("1234_second", MsgStateEnum.POSTPONED, Instant.now());
+                insertNewMessage("1234_first", MsgStateEnum.POSTPONED, Instant.now().minusSeconds(150));
+            }
+        });
+    }
+
+    @Test
+    public void testDoNotify_ok() throws Exception {
+        final Message inputMsg = getMessage("1234", MsgStateEnum.OK, Instant.now());
+
+        // prepare exchange for event
+        final ExchangeBuilder exchangeBuilder = ExchangeBuilder.anExchange(producerTemplate.getCamelContext());
+        final Exchange exchange = exchangeBuilder.build();
+        exchange.getIn().setHeader(AsynchConstants.MSG_HEADER, inputMsg);
+
+        mock.expectedMessageCount(1);
+
+        // publish event
+        AsynchEventHelper.notifyGuaranteedOrderMsgCompleted(exchange);
+
+        mock.assertIsSatisfied();
+
+        // verify message
+        Message nextMsg = mock.getExchanges().get(0).getIn().getBody(Message.class);
+        assertThat(nextMsg, notNullValue());
+        assertThat(nextMsg.getCorrelationId(), is("1234_first"));
+        assertThat(nextMsg.getPayload(), is("xml"));
+        assertThat(nextMsg.getSourceSystem().getSystemName(), is("CRM"));
+        assertThat(nextMsg.getService().getServiceName(), is("CUSTOMER"));
+        assertThat(nextMsg.getOperationName(), is("setCustomer"));
+        assertThat(nextMsg.getFunnelValue(), is("funnelValue"));
+        assertThat(nextMsg.isGuaranteedOrder(), is(true));
+    }
+
+    @Test
+    public void testDoNotify_noNextMsg() throws Exception {
+        final Message inputMsg = getMessage("1234", MsgStateEnum.OK, Instant.now());
+        inputMsg.setFunnelValue("anotherFunnel");
+
+        // prepare exchange for event
+        final ExchangeBuilder exchangeBuilder = ExchangeBuilder.anExchange(producerTemplate.getCamelContext());
+        final Exchange exchange = exchangeBuilder.build();
+        exchange.getIn().setHeader(AsynchConstants.MSG_HEADER, inputMsg);
+
+        mock.expectedMessageCount(0);
+
+        // publish event
+        AsynchEventHelper.notifyGuaranteedOrderMsgCompleted(exchange);
+
+        mock.assertIsSatisfied();
+    }
+
+    private Message insertNewMessage(String correlationId, MsgStateEnum state, Instant msgTimestamp) {
+        final Message msg = getMessage(correlationId, state, msgTimestamp);
+
+        em.persist(msg);
+        em.flush();
+
+        return msg;
+    }
+
+    private Message getMessage(String correlationId, MsgStateEnum state, Instant msgTimestamp) {
+        final Instant currDate = Instant.now();
+
+        final Message msg = new Message();
+        msg.setState(state);
+        msg.setMsgTimestamp(msgTimestamp);
+        msg.setReceiveTimestamp(currDate);
+        msg.setLastUpdateTimestamp(currDate);
+        msg.setSourceSystem(ExternalSystemTestEnum.CRM);
+        msg.setCorrelationId(correlationId);
+        msg.setService(ServiceTestEnum.CUSTOMER);
+        msg.setOperationName("setCustomer");
+        msg.setObjectId(null);
+        msg.setFunnelValue("funnelValue");
+        msg.setGuaranteedOrder(true);
+        msg.setPayload("xml");
+
+        return msg;
+    }
+}


### PR DESCRIPTION
### Current
Messages in guaranteed order are pooled by job in defined period (e.g. 60 seconds). In each round only one message is selected and processed. When there are a lot of messages it may take a long time.

### Improvement

- added new event `GuaranteedOrderMsgAsynchEvent` which is triggered at the end of processing
- added new event notifier `GuaranteedOrderMsgEventNotifier` which finds and process following guaranteed order message